### PR TITLE
Add 'white-space: pre-line' to descriptions

### DIFF
--- a/packages/client/components/molecules/Result.tsx
+++ b/packages/client/components/molecules/Result.tsx
@@ -101,7 +101,7 @@ export function Result(props: Props) {
           },
         }}
       >
-        <Text style={{ whiteSpace: "pre-wrap" }}>{parseHtml(props.description ?? '')}</Text>
+        <Text sx={{ whiteSpace: "pre-wrap" }}>{parseHtml(props.description ?? '')}</Text>
       </Spoiler>
 
       <Stack mt="lg" mb="lg" spacing="sm">

--- a/packages/client/components/molecules/Result.tsx
+++ b/packages/client/components/molecules/Result.tsx
@@ -101,7 +101,7 @@ export function Result(props: Props) {
           },
         }}
       >
-        <Text>{parseHtml(props.description ?? '')}</Text>
+        <Text style={{ whiteSpace: "pre-wrap" }}>{parseHtml(props.description ?? '')}</Text>
       </Spoiler>
 
       <Stack mt="lg" mb="lg" spacing="sm">

--- a/packages/client/components/organisms/ResourceOverviewSection.tsx
+++ b/packages/client/components/organisms/ResourceOverviewSection.tsx
@@ -74,7 +74,7 @@ export function ResourceOverviewSection(props: Props) {
         {props.serviceName}
       </Text>
 
-      <Text mb="lg" style={{ whiteSpace: "pre-wrap" }}>{parseHtml(props.serviceDescription ?? '')}</Text>
+      <Text mb="lg" sx={{ whiteSpace: "pre-wrap" }}>{parseHtml(props.serviceDescription ?? '')}</Text>
 
       <Divider />
 

--- a/packages/client/components/organisms/ResourceOverviewSection.tsx
+++ b/packages/client/components/organisms/ResourceOverviewSection.tsx
@@ -74,7 +74,7 @@ export function ResourceOverviewSection(props: Props) {
         {props.serviceName}
       </Text>
 
-      <Text mb="lg">{parseHtml(props.serviceDescription ?? '')}</Text>
+      <Text mb="lg" style={{ whiteSpace: "pre-wrap" }}>{parseHtml(props.serviceDescription ?? '')}</Text>
 
       <Divider />
 


### PR DESCRIPTION
Added `white-space: pre-line` property resolving the problem #69 