### PR TITLE
Fix/crash when no resource

### DIFF
--- a/src/features/resource/views/resource-view.tsx
+++ b/src/features/resource/views/resource-view.tsx
@@ -13,6 +13,15 @@ export function ResourceView({ resource }) {
   const appConfig = useAppConfig();
   const componentToPrintRef = useRef();
 
+  if (!resource) {
+    // Handle the case where resource is null or undefined.
+    return (
+      <div>
+        <h1>Resource not found</h1>
+      </div>
+    );
+  }
+
   return (
     <>
       <Head>

--- a/src/features/search/components/taxonomy-container.tsx
+++ b/src/features/search/components/taxonomy-container.tsx
@@ -42,7 +42,7 @@ export function TaxonomyContainer() {
       const codes = new Set<string>();
       if (typeof query === 'string') {
         query.split(',').forEach((code) => {
-          codes.add(code);
+          codes.add(code.trim());
         });
         return Array.from(codes);
       }

--- a/src/features/search/components/taxonomy-container.tsx
+++ b/src/features/search/components/taxonomy-container.tsx
@@ -14,6 +14,15 @@ type TaxonomyComplexQuery =
     }
   | string;
 
+interface TaxonomyBadgeData {
+  code: string | null | undefined;
+  name: string | null | undefined;
+}
+
+interface Props {
+  data: TaxonomyBadgeData[] | null | undefined;
+}
+
 export function TaxonomyContainer() {
   const router = useRouter();
   const [taxonomies, setTaxonomies] = useState<string[]>([]);
@@ -100,17 +109,34 @@ export function TaxonomyContainer() {
     }
   }, [router.query, extractTaxonomyCodes]);
 
+  // Deduplicate data based on code
+  const uniqueTaxonomies = data?.reduce<TaxonomyBadgeData[]>((acc, tax) => {
+    if (!tax || !tax.code || !tax.name) {
+      return acc; // Skip invalid entries
+    }
+    if (!acc.find((t) => t.code === tax.code)) {
+      acc.push(tax);
+    }
+    return acc;
+  }, []);
+
   return (
     <div className="flex flex-wrap gap-1">
-      {data?.map((tax) => (
-        <Link
-          key={tax.code}
-          className={cn(badgeVariants(), 'hover:underline')}
-          href={`/search?query=${tax.code}&query_label=${tax.name}&query_type=taxonomy`}
-        >
-          {tax.name}
-        </Link>
-      ))}
+      {uniqueTaxonomies?.map((tax) => {
+        if (!tax || !tax.name || !tax.code) {
+          return null;
+        }
+
+        return (
+          <Link
+            key={tax.code}
+            className={cn(badgeVariants(), 'hover:underline')}
+            href={`/search?query=${tax.code}&query_label=${tax.name}&query_type=taxonomy`}
+          >
+            {tax.name}
+          </Link>
+        );
+      })}
     </div>
   );
 }

--- a/src/pages/search/[id].tsx
+++ b/src/pages/search/[id].tsx
@@ -39,6 +39,12 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 
   cacheControl(ctx);
 
+  if (notFound) {
+    return {
+      notFound: true,
+    };
+  }
+
   return {
     props: {
       resource: data,
@@ -50,7 +56,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
         'dynamic',
       ])),
     },
-    notFound,
   };
 }
 

--- a/src/shared/services/resource-service.ts
+++ b/src/shared/services/resource-service.ts
@@ -9,17 +9,19 @@ export class ResourceService {
     id: string,
     options: { locale: string },
   ): Promise<any> {
-    const { data } = await Axios.get(`${API_URL}/${this.endpoint}/${id}`, {
-      headers: {
-        'accept-language': options.locale,
-        'x-api-version': '1',
-      },
-      params: {
-        locale: options.locale,
-      },
-    });
+    const url = `${API_URL}/${this.endpoint}/${id}`;
+    const headers = {
+      'accept-language': options.locale,
+      'x-api-version': '1',
+    };
+    const params = {
+      locale: options.locale,
+    };
 
-    console.log(data);
+    const { data } = await Axios.get(url, {
+      headers: headers,
+      params: params,
+    });
 
     return {
       id: data._id,


### PR DESCRIPTION
Improve taxonomy badge rendering
- Deduplicate taxonomy badges based on `code` to prevent duplicates.
- Skip rendering links when `name` or `code` is null/undefined.