### PR TITLE
Feat: Customizable provider callouts and categories heading

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Pre-build",
+      "runtimeExecutable": "node",
+      "runtimeArgs": [
+        "-r",
+        "dotenv/config",
+        "${workspaceFolder}/bin/pre-build.js"
+      ]
+    }
+  ]
+}

--- a/bin/createAppFromStrapi.js
+++ b/bin/createAppFromStrapi.js
@@ -27,6 +27,10 @@ const query = qs.stringify({
         'lastAssuredText',
         'categoriesText',
         'hideAttribution',
+        'hideCategoriesHeading',
+        'customCategoriesHeading',
+        'hideDataProvidersHeading',
+        'customDataProvidersHeading',
         'headerMenu',
         'footerMenu',
         'map',
@@ -137,6 +141,8 @@ module.exports = function createFromStrapi(dir) {
       alert: appConfig?.alert,
       theme: appConfig?.theme,
       hideAttribution: appConfig?.hideAttribution ?? true,
+      hideCategoriesHeading: appConfig?.hideCategoriesHeading ?? false,
+      hideDataProvidersHeading: appConfig?.hideDataProvidersHeading ?? false,
       pages: {},
       menus: {
         header: [],
@@ -152,23 +158,29 @@ module.exports = function createFromStrapi(dir) {
       sms: appConfig?.sms,
     };
 
-    translationFile['en']['search.hero_title'] = appConfig.search.homePageTitle;
-    translationFile['en']['search.query_placeholder'] =
-      appConfig.search.queryInputPlaceholder;
-    translationFile['en']['search.location_placeholder'] =
-      appConfig.search.locationInputPlaceholder;
-    translationFile['en']['search.no_results_fallback_text'] =
-      appConfig?.search?.noResultsFallbackText;
-    translationFile['en']['last_assured_text'] =
-      appConfig?.resourcePage?.lastAssuredText;
-    translationFile['en']['categories_text'] =
-      appConfig?.resourcePage?.categoriesText;
+    const translations = {
+      'search.hero_title': appConfig.search.homePageTitle,
+      'search.query_placeholder': appConfig.search.queryInputPlaceholder,
+      'search.location_placeholder': appConfig.search.locationInputPlaceholder,
+      'search.no_results_fallback_text':
+        appConfig?.search?.noResultsFallbackText,
+      last_assured_text: appConfig?.resourcePage?.lastAssuredText,
+      categories_text: appConfig?.resourcePage?.categoriesText,
+      meta_title: appConfig?.homePage?.title,
+      meta_description: appConfig?.homePage?.description,
+    };
 
-    translationFile['en']['meta_title'] = appConfig?.homePage?.title;
-    translationFile['en']['meta_description'] =
-      appConfig?.homePage?.description;
+    if (appConfig?.customCategoriesHeading) {
+      translations['search.categories_heading'] =
+        appConfig.customCategoriesHeading;
+    }
+    if (appConfig?.customDataProvidersHeading) {
+      translations['search.data_providers_heading'] =
+        appConfig.customDataProvidersHeading;
+    }
 
-    // Add hero section URL
+    translationFile['en'] = translations;
+
     newAppConfig.pages['home'] = {
       heroSection: {
         backgroundImageUrl: heroUrl,
@@ -201,26 +213,28 @@ module.exports = function createFromStrapi(dir) {
 
     for (const locale of appConfigTranslations || []) {
       const data = locale.attributes;
-      if (!translationFile[data.locale]) {
-        translationFile[data.locale] = {};
+
+      const translations = {
+        'search.hero_title': data?.search?.homePageTitle,
+        'search.query_placeholder': data?.search?.queryInputPlaceholder,
+        'search.location_placeholder': data?.search?.locationInputPlaceholder,
+        'search.no_results_fallback_text': data?.search?.noResultsFallbackText,
+        last_assured_text: data?.resourcePage?.lastAssuredText,
+        categories_text: data?.resourcePage?.categoriesText,
+        meta_title: data?.homePage?.title,
+        meta_description: data?.homePage?.description,
+      };
+
+      if (data?.customCategoriesHeading) {
+        translations['search.categories_heading'] =
+          data.customCategoriesHeading;
+      }
+      if (data?.customDataProvidersHeading) {
+        translations['search.data_providers_heading'] =
+          data.customDataProvidersHeading;
       }
 
-      translationFile[data.locale]['search.hero_title'] =
-        data?.search?.homePageTitle;
-      translationFile[data.locale]['search.query_placeholder'] =
-        data?.search?.queryInputPlaceholder;
-      translationFile[data.locale]['search.location_placeholder'] =
-        data?.search?.locationInputPlaceholder;
-      translationFile[data.locale]['search.no_results_fallback_text'] =
-        data?.search?.noResultsFallbackText;
-      translationFile[data.locale]['last_assured_text'] =
-        data?.resourcePage?.lastAssuredText;
-      translationFile[data.locale]['categories_text'] =
-        data?.resourcePage?.categoriesText;
-
-      translationFile[data.locale]['meta_title'] = data?.homePage?.title;
-      translationFile[data.locale]['meta_description'] =
-        data?.homePage?.description;
+      translationFile[data.locale] = translations;
     }
 
     const categoryFiles = {};

--- a/src/features/home/components/categories-section.tsx
+++ b/src/features/home/components/categories-section.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from '@/shared/components/ui/card';
 import { useCategories } from '@/shared/hooks/use-categories';
 import { ExternalLink } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
+import { useAppConfig } from '@/shared/hooks/use-app-config';
 
 type Props = {
   index: string;
@@ -92,15 +93,25 @@ const Category = ({ image, name, href, target, subcategories }: Props) => {
 
 export function CategoriesSection() {
   const { t } = useTranslation('page-home');
+  const appConfig = useAppConfig();
   const categories = useCategories();
 
   if ((categories?.length ?? 0) === 0) return null;
 
   return (
     <div className="categories container mx-auto pb-8 pt-8">
-      <h3 className="text-2xl font-bold">{t('categories_title')}</h3>
+      {!appConfig.hideCategoriesHeading && (
+        <>
+          <h3 className="text-2xl font-bold">
+            {t('search.categories_heading', {
+              ns: 'dynamic',
+              defaultValue: t('categories_title'),
+            })}
+          </h3>
 
-      <Separator className="mb-4 mt-4" />
+          <Separator className="mb-4 mt-4" />
+        </>
+      )}
 
       <div
         className={cn(

--- a/src/shared/components/data-providers.tsx
+++ b/src/shared/components/data-providers.tsx
@@ -10,57 +10,100 @@ export function DataProviders() {
   const appConfig = useAppConfig();
   const { t } = useTranslation();
 
+  const validProviders =
+    appConfig?.providers?.filter(
+      (provider: any) => provider.name || provider.logo,
+    ) || [];
+
+  if (validProviders.length === 0) {
+    return null;
+  }
+
   return (
     <>
-      {appConfig?.providers?.length > 0 && (
-        <>
-          <div className="container mx-auto flex flex-col pb-8 pt-8">
+      <div className="container mx-auto flex flex-col pb-8 pt-8">
+        {!appConfig.hideDataProvidersHeading && (
+          <>
             <h3 className="text-lg font-semibold">
-              {t('data_providers.provided_by')}
+              {t('search.data_providers_heading', {
+                ns: 'dynamic',
+                defaultValue: t('data_providers.provided_by'),
+              })}
             </h3>
 
             <Separator className="mb-4" />
+          </>
+        )}
 
-            <div
-              className={cn(
-                appConfig.providers.length >= 4 &&
-                  'grid-cols-1 justify-center sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
-                appConfig.providers.length === 3 &&
-                  'mx-auto max-w-fit grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
-                appConfig.providers.length === 2 &&
-                  'mx-auto max-w-fit grid-cols-1 sm:grid-cols-2',
-                appConfig.providers.length === 1 &&
-                  'mx-auto max-w-fit grid-cols-1',
-                'grid gap-4',
-              )}
-            >
-              {appConfig.providers.map((el: any) => (
-                <Link
-                  key={el.name}
-                  href={el.href}
-                  target="_blank"
-                  className="group self-stretch hover:underline"
-                >
-                  <Card className="h-full transition-all group-hover:shadow-sm">
-                    <CardHeader className="transition-all group-hover:translate-x-1">
-                      <CardTitle>{el.name}</CardTitle>
-                    </CardHeader>
-                    <CardContent className="transition-all group-hover:translate-x-1">
-                      <Image
-                        src={el.logo}
-                        alt=""
-                        width={200}
-                        height={0}
-                        style={{ width: '200px', height: 'auto' }}
-                      />
-                    </CardContent>
-                  </Card>
-                </Link>
-              ))}
-            </div>
-          </div>
-        </>
-      )}
+        <div
+          className={cn(
+            validProviders.length >= 4 &&
+              'grid-cols-1 justify-center sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+            validProviders.length === 3 &&
+              'mx-auto max-w-fit grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+            validProviders.length === 2 &&
+              'mx-auto max-w-fit grid-cols-1 sm:grid-cols-2',
+            validProviders.length === 1 && 'mx-auto max-w-fit grid-cols-1',
+            'grid gap-4',
+          )}
+        >
+          {validProviders.map((el: any) => {
+            const key = el.name || `provider-${Math.random()}`;
+            const CardNameAndLogoComponent = (
+              <Card className="h-full transition-all group-hover:shadow-sm">
+                <CardHeader className="transition-all group-hover:translate-x-1">
+                  <CardTitle>{el.name}</CardTitle>
+                </CardHeader>
+                <CardContent className="transition-all group-hover:translate-x-1">
+                  <Image
+                    src={el.logo}
+                    alt=""
+                    width={200}
+                    height={0}
+                    style={{ width: '200px', height: 'auto' }}
+                  />
+                </CardContent>
+              </Card>
+            );
+            const CardNameOrLogoComponent = (
+              <Card className="flex h-full items-center justify-center transition-all group-hover:shadow-sm">
+                <CardHeader className="transition-all group-hover:translate-x-1">
+                  {el.name && <CardTitle>{el.name}</CardTitle>}
+                  {el.logo && (
+                    <Image
+                      src={el.logo}
+                      alt=""
+                      width={200}
+                      height={0}
+                      style={{ width: '200px', height: 'auto' }}
+                    />
+                  )}
+                </CardHeader>
+              </Card>
+            );
+
+            const CardComponent =
+              el.name && el.logo
+                ? CardNameAndLogoComponent
+                : CardNameOrLogoComponent;
+
+            return el.href ? (
+              <Link
+                key={key}
+                href={el.href}
+                target="_blank"
+                className="group self-stretch hover:underline"
+              >
+                {CardComponent}
+              </Link>
+            ) : (
+              <div key={key} className="group self-stretch">
+                {CardComponent}
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </>
   );
 }

--- a/src/shared/context/app-config-context.ts
+++ b/src/shared/context/app-config-context.ts
@@ -55,6 +55,8 @@ export type AppConfig = {
     url?: string;
   };
   hideAttribution?: boolean;
+  hideCategoriesHeading?: boolean;
+  hideDataProvidersHeading?: boolean;
   providers?: {
     name?: string;
     href?: string;


### PR DESCRIPTION
This PR makes it possible to:
- hide or change Categories heading
![image](https://github.com/user-attachments/assets/5893e0f7-ed0f-49ba-898e-51e9c7913638)
![image](https://github.com/user-attachments/assets/3ba67c34-0e12-48f0-96e0-8c410f7a92b2)
- hide or change Providers heading
![image](https://github.com/user-attachments/assets/3a78c384-55cd-4b1b-81c1-d6d7fd9e8034)
![image](https://github.com/user-attachments/assets/be4671ba-51b5-40b6-a9bc-66406e63507d)
- use only logo or name in Provider details
![image](https://github.com/user-attachments/assets/112f7aaf-d0f7-444b-994b-7a804572fcdf)
