### PR TITLE
Feat: Allow running engine on subpath

### DIFF
--- a/src/pages/api/share/[id].ts
+++ b/src/pages/api/share/[id].ts
@@ -5,12 +5,11 @@ import { ShortUrlService } from '@/shared/services/short-url-service';
 const ShareHandler: NextApiHandler = async (req, res) => {
   if (req.method !== 'GET' && req.method !== 'POST') res.redirect('/');
 
-
   if (req.method === 'GET') {
     const id = req.query.id;
     try {
-      const response = await ShortUrlService.getShortUrlById(id as string);
-      if (response) res.redirect(response.url);
+      const url = await ShortUrlService.expandUrl(id as string);
+      if (url) res.redirect(url);
       else res.redirect('/404');
     } catch (err) {
       if (isAxiosError(err)) {

--- a/src/shared/components/providers.tsx
+++ b/src/shared/components/providers.tsx
@@ -1,3 +1,4 @@
+import getConfig from 'next/config';
 import { SessionProvider } from 'next-auth/react';
 import { CookiesProvider } from 'react-cookie';
 import { Provider as JotaiProvider } from 'jotai';
@@ -6,16 +7,18 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PageView } from './page-view';
 import { PrevUrlProvider } from '../context/prev-url-provider';
 import { FlagsProvider } from '../context/flags-provider';
+import { useRouter } from 'next/router';
 
 const queryClient = new QueryClient();
 
 export function Providers({ session, appConfig, flags, children }) {
+  const { basePath } = useRouter();
+
   return (
     <JotaiProvider>
       <PageView />
-
       <QueryClientProvider client={queryClient}>
-        <SessionProvider session={session}>
+        <SessionProvider basePath={`${basePath}/api/auth`} session={session}>
           <FlagsProvider value={flags}>
             <AppConfigProvider value={appConfig}>
               <CookiesProvider>

--- a/src/shared/components/share-button.tsx
+++ b/src/shared/components/share-button.tsx
@@ -22,9 +22,11 @@ import { X } from './icons/x';
 import { ShortUrlService } from '../services/short-url-service';
 import { useClipboard } from '../hooks/use-clipboard';
 import { SmsButton } from './sms-button';
+import { useRouter } from 'next/router';
 
 export function ShareButton({ componentToPrintRef, title = '', body = '' }) {
   const { t } = useTranslation('common');
+  const { basePath } = useRouter();
   const [open, setOpen] = useState(false);
   const clipboard = useClipboard();
   const handlePrint = useReactToPrint({
@@ -34,14 +36,13 @@ export function ShareButton({ componentToPrintRef, title = '', body = '' }) {
 
   useEffect(() => {
     async function getShortUrl() {
-      const { url } = await ShortUrlService.getOrCreateShortUrl(
-        window.location.href,
-      );
+      const id = await ShortUrlService.shortenUrl(window.location.href);
+      const url = `${window.location.origin}${basePath}/api/share/${id}`;
       setShortUrl(url);
     }
 
     getShortUrl();
-  }, []);
+  }, [basePath]);
 
   return (
     <>

--- a/src/shared/services/short-url-service.ts
+++ b/src/shared/services/short-url-service.ts
@@ -4,17 +4,17 @@ import { Axios } from '../lib/axios';
 export class ShortUrlService {
   static endpoint = 'short-url';
 
-  static async getShortUrlById(id: string) {
+  static async expandUrl(id: string): Promise<string | null> {
     const res = await Axios.get(`${API_URL}/${this.endpoint}/${id}`, {
       headers: {
         'x-api-version': '1',
       },
     });
 
-    return res.data;
+    return res.data?.url || null;
   }
 
-  static async getOrCreateShortUrl(url: string) {
+  static async shortenUrl(url: string): Promise<string | null> {
     const res = await Axios.post(
       `${API_URL}/${this.endpoint}`,
       {
@@ -27,22 +27,16 @@ export class ShortUrlService {
       },
     );
 
-    return res.data;
-  }
+    const shortUrl = res.data?.url;
+    if (!shortUrl) {
+      return null;
+    }
 
-  static async createShortUrl(url: string): Promise<{ url: string }> {
-    const { data } = await Axios.post(
-      `/${this.endpoint}`,
-      {
-        url,
-      },
-      {
-        headers: {
-          'x-api-version': '1',
-        },
-      },
-    );
+    // Backend shouldn't return frontend URLs really,
+    // keep it straightforward and backwards compatible
+    // by extracting the ID from the short URL.
+    const id = shortUrl.split('/').pop();
 
-    return data;
+    return id;
   }
 }


### PR DESCRIPTION
This PR extends the engine implementation to support deploying on subpaths (e.g., `https://my-domain.com/search-engine`). To achieve this, you need to:
- Set `basePath` in the Next.js config via config file or via Strapi
- Update the `NEXTAUTH_URL` environment variable to include the full `/api/auth` path

Example:
- `"basePath": "/search-engine"`
- `NEXTAUTH_URL=https://my-domain.com/search-engine/api/auth`

Normally, NextAuth.js handles `NEXTAUTH_URL` without the `/api/auth` part, but when using subpaths, it must be fully specified.

Tested with Next.JS + Apache with simple proxy config, no additional rewriting is needed:
```
ProxyPreserveHost On
ProxyPass /adresources http://host.docker.internal:3000/adresources
ProxyPassReverse /adresources http://host.docker.internal:3000/adresources
```