### PR TITLE
fix(accessibility): resource & search WCAG remediation — result cards, resource detail, maps (MNADR-107 to MNADR-147)

### DIFF
--- a/src/app/(app)/features/resource/components/back-to-results-button.tsx
+++ b/src/app/(app)/features/resource/components/back-to-results-button.tsx
@@ -1,30 +1,43 @@
 'use client';
 
-import { Button } from '@/app/(app)/shared/components/ui/button';
+import { Link } from '@/app/(app)/shared/components/link';
+import { Button, buttonVariants } from '@/app/(app)/shared/components/ui/button';
+import { cn } from '@/app/(app)/shared/lib/utils';
 import { usePrevUrl } from '@/app/(app)/shared/hooks/use-prev-url';
 import { ChevronLeft } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export function BackToResultsButton() {
-  const router = useRouter();
   const prevUrl = usePrevUrl();
   const { t } = useTranslation('page-resource');
 
-  const isSearchPage = prevUrl?.includes('/search');
+  const [backUrl, setBackUrl] = useState<string | 'loading'>('loading');
 
-  const handleClick = () => {
-    if (isSearchPage && prevUrl) {
-      router.push(prevUrl);
+  useEffect(() => {
+    if (prevUrl && /\/search\/?(\?|$)/.test(prevUrl)) {
+      setBackUrl(prevUrl);
     } else {
-      router.back();
+      setBackUrl('/');
     }
-  };
+  }, [prevUrl]);
+
+  if (backUrl === 'loading') {
+    return (
+      <Button variant="outline" className="flex gap-1" disabled>
+        <ChevronLeft aria-hidden="true" className="size-4" />
+        {t('back_to_results')}
+      </Button>
+    );
+  }
 
   return (
-    <Button variant="outline" className="flex gap-1" onClick={handleClick}>
-      <ChevronLeft className="size-4" />
-      {isSearchPage ? t('back_to_results') : t('back_to_home')}
-    </Button>
+    <Link
+      className={cn(buttonVariants({ variant: 'outline' }), 'flex gap-1')}
+      href={backUrl}
+    >
+      <ChevronLeft aria-hidden="true" className="size-4" />
+      {backUrl === '/' ? t('back_to_home') : t('back_to_results')}
+    </Link>
   );
 }

--- a/src/app/(app)/features/resource/components/datum.tsx
+++ b/src/app/(app)/features/resource/components/datum.tsx
@@ -14,6 +14,7 @@ export interface DatumProps {
   iconColor?: string | null;
   url?: string | null;
   urlTarget?: '_blank' | '_self' | null;
+  urlAriaLabel?: string | null;
   titleBelow?: boolean | null;
   singleLine?: boolean;
   size?: 'sm' | 'md' | null;
@@ -31,6 +32,7 @@ export function Datum({
   iconColor,
   url,
   urlTarget = '_self',
+  urlAriaLabel,
   titleBelow,
   singleLine = false,
   size = 'sm',
@@ -61,6 +63,7 @@ export function Datum({
       <div>
         {Icon ? (
           <Icon
+            aria-hidden="true"
             className={cn('my-1 size-4', iconColor)}
             style={
               iconColor?.startsWith('#') ? { color: iconColor } : undefined
@@ -76,6 +79,7 @@ export function Datum({
             url={url}
             urlTarget={urlTarget}
             as={descriptionAs}
+            aria-label={urlAriaLabel ?? undefined}
           >
             {parsedDescription}
           </Typography>
@@ -100,6 +104,7 @@ export function Datum({
             url={url}
             urlTarget={urlTarget}
             as={descriptionAs}
+            aria-label={urlAriaLabel ?? undefined}
           >
             {parsedDescription}
           </Typography>

--- a/src/app/(app)/features/resource/components/resource-components/facets.tsx
+++ b/src/app/(app)/features/resource/components/resource-components/facets.tsx
@@ -102,18 +102,21 @@ export function FacetsComponent({ resource }: { resource: Resource }) {
       <div className="flex flex-col gap-6">
         {Object.entries(filteredFacets).map(([taxonomyName, facets]) => (
           <div key={taxonomyName} className="flex flex-col gap-2">
-            <p className="text-sm font-semibold">{taxonomyName}</p>
-            <div className="flex flex-col gap-2">
+            <h3 className="text-sm font-semibold">{taxonomyName}</h3>
+            <ul className="flex flex-col gap-2">
               {facets.map((facet, index) => (
-                <div
+                <li
                   key={`${facet.code}-${index}`}
                   className="flex items-start gap-2"
                 >
-                  <SquareCheck className="mt-0.5 size-4 shrink-0 text-[#bbbbbb]" />
+                  <SquareCheck
+                    aria-hidden="true"
+                    className="mt-0.5 size-4 shrink-0 text-[#bbbbbb]"
+                  />
                   <span className="text-sm">{facet.termName}</span>
-                </div>
+                </li>
               ))}
-            </div>
+            </ul>
           </div>
         ))}
       </div>

--- a/src/app/(app)/features/resource/components/resource-components/phone-numbers.tsx
+++ b/src/app/(app)/features/resource/components/resource-components/phone-numbers.tsx
@@ -46,6 +46,7 @@ export function PhoneNumbersComponent({ resource }: { resource: Resource }) {
           subtitle={description}
           description={number}
           url={`tel:${number}`}
+          urlAriaLabel={`${label}${description ? ` - ${description}` : ''}: ${number}`}
           onClick={() =>
             trackUmamiEvent(UmamiEvent.PhoneClick, {
               resourceId: resource.id,

--- a/src/app/(app)/features/search/components/search-card-components/action-buttons.tsx
+++ b/src/app/(app)/features/search/components/search-card-components/action-buttons.tsx
@@ -30,12 +30,12 @@ export function ActionButtonsComponent({ result }: SearchCardComponentProps) {
             window.open(`tel:${result.phone}`);
           }}
         >
-          <Phone className="size-4" />{' '}
+          <Phone aria-hidden="true" className="size-4" />{' '}
           <span className="truncate"> {t('call_to_action.call')} </span>
         </ReferralButton>
 
         <ReferralButton
-          className="flex-1 gap-1 overflow-hidden"
+          className="min-h-8 flex-1 gap-1 whitespace-normal py-2"
           referralType="website_referral"
           size="sm"
           resourceId={result.id}
@@ -46,12 +46,14 @@ export function ActionButtonsComponent({ result }: SearchCardComponentProps) {
             window.open(result.website, '_blank');
           }}
         >
-          <LinkIcon className="size-4" />{' '}
-          <span className="truncate">{t('call_to_action.view_website')}</span>
+          <LinkIcon aria-hidden="true" className="size-4 shrink-0" />{' '}
+          <span className="text-center leading-tight">
+            {t('call_to_action.view_website')}
+          </span>
         </ReferralButton>
 
         <GetDirectionsButton
-          className="overflow-hidden"
+          className="min-h-8 whitespace-normal py-2"
           data={result}
           coords={searchCoords}
         />
@@ -64,6 +66,7 @@ export function ActionButtonsComponent({ result }: SearchCardComponentProps) {
             buttonVariants({ variant: 'ghost' }),
           )}
           href={`/search/${result.id}`}
+          aria-label={`${t('call_to_action.view_details')}: ${result.name}`}
         >
           {t('call_to_action.view_details')}
         </Link>

--- a/src/app/(app)/shared/components/global-dialogs/promt-auth-dialog.tsx
+++ b/src/app/(app)/shared/components/global-dialogs/promt-auth-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAtomValue, useSetAtom } from 'jotai';
-import { signIn } from 'next-auth/react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { dialogsAtom, promptAuthAtom } from '@/app/(app)/shared/store/dialogs';
 
@@ -13,12 +13,20 @@ import {
   DialogTitle,
 } from '../ui/dialog';
 import { Button } from '../ui/button';
+import { cn } from '../../lib/utils';
+import { buttonVariants } from '../ui/button';
 
 export function PromptAuthDialog() {
   const setState = useSetAtom(dialogsAtom);
   const state = useAtomValue(promptAuthAtom);
+  const [loginHref, setLoginHref] = useState('/api/auth/signin/keycloak');
 
   const { t } = useTranslation('common');
+
+  useEffect(() => {
+    const callbackUrl = encodeURIComponent(window.location.href);
+    setLoginHref(`/api/auth/signin/keycloak?callbackUrl=${callbackUrl}`);
+  }, []);
 
   const handleOpenChange = (value: boolean) => {
     setState((prev) => ({
@@ -43,14 +51,14 @@ export function PromptAuthDialog() {
               {t('call_to_action.cancel')}
             </Button>
 
-            <Button
-              onClick={() =>
-                signIn('keycloak', { callbackUrl: window.location.href })
-              }
+            <a
+              className={cn(buttonVariants(), 'inline-flex')}
+              href={loginHref}
               data-testid="login-btn"
+              onClick={() => handleOpenChange(false)}
             >
               {t('call_to_action.login')}
-            </Button>
+            </a>
           </div>
         </div>
       </DialogContent>

--- a/src/app/(app)/shared/components/global-dialogs/promt-auth-dialog.tsx
+++ b/src/app/(app)/shared/components/global-dialogs/promt-auth-dialog.tsx
@@ -1,17 +1,10 @@
 'use client';
 
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { dialogsAtom, promptAuthAtom } from '@/app/(app)/shared/store/dialogs';
 
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '../ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
 import { Button } from '../ui/button';
 import { cn } from '../../lib/utils';
 import { buttonVariants } from '../ui/button';
@@ -19,14 +12,7 @@ import { buttonVariants } from '../ui/button';
 export function PromptAuthDialog() {
   const setState = useSetAtom(dialogsAtom);
   const state = useAtomValue(promptAuthAtom);
-  const [loginHref, setLoginHref] = useState('/api/auth/signin/keycloak');
-
   const { t } = useTranslation('common');
-
-  useEffect(() => {
-    const callbackUrl = encodeURIComponent(window.location.href);
-    setLoginHref(`/api/auth/signin/keycloak?callbackUrl=${callbackUrl}`);
-  }, []);
 
   const handleOpenChange = (value: boolean) => {
     setState((prev) => ({
@@ -38,28 +24,29 @@ export function PromptAuthDialog() {
     }));
   };
 
+  const loginHref = `/api/auth/signin/keycloak?callbackUrl=${encodeURIComponent(
+    typeof window !== 'undefined' ? window.location.href : '',
+  )}`;
+
   return (
     <Dialog open={state.open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{t('modal.prompt_auth')}</DialogTitle>
-          <DialogDescription />
         </DialogHeader>
-        <div className="flex justify-end">
-          <div className="grid grid-cols-2 gap-2">
-            <Button onClick={() => handleOpenChange(false)} variant="outline">
-              {t('call_to_action.cancel')}
-            </Button>
+        <div className="flex justify-end gap-2">
+          <Button onClick={() => handleOpenChange(false)} variant="outline">
+            {t('call_to_action.cancel')}
+          </Button>
 
-            <a
-              className={cn(buttonVariants(), 'inline-flex')}
-              href={loginHref}
-              data-testid="login-btn"
-              onClick={() => handleOpenChange(false)}
-            >
-              {t('call_to_action.login')}
-            </a>
-          </div>
+          <a
+            className={cn(buttonVariants(), 'inline-flex')}
+            href={loginHref}
+            data-testid="login-btn"
+            onClick={() => handleOpenChange(false)}
+          >
+            {t('call_to_action.login')}
+          </a>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/app/(app)/shared/components/map/mapbox/map.tsx
+++ b/src/app/(app)/shared/components/map/mapbox/map.tsx
@@ -42,6 +42,21 @@ export function Map({
   const _markers = useRef<mapboxgl.Marker[]>([]);
   const [mapError, setMapError] = useState<string | null>(null);
 
+  const applyMarkerSemantics = (
+    markerElement: HTMLElement,
+    interactive: boolean,
+  ) => {
+    if (!interactive) {
+      markerElement.removeAttribute('aria-label');
+      markerElement.removeAttribute('role');
+      markerElement.removeAttribute('tabindex');
+      markerElement.setAttribute('aria-hidden', 'true');
+      return;
+    }
+
+    markerElement.removeAttribute('aria-hidden');
+  };
+
   useEffect(() => {
     try {
       mapboxMap.current = new mapboxgl.Map({
@@ -96,14 +111,17 @@ export function Map({
       }
 
       const markerElement = marker.getElement();
-      markerElement.style.cursor = 'pointer';
       markerElement.classList.add('custom-marker');
-      markerElement.addEventListener('click', () => {
-        setTimeout(() => {
-          const listElement = document.getElementById(m.id);
-          listElement?.scrollIntoView();
+      if (m.popup) {
+        markerElement.style.cursor = 'pointer';
+        markerElement.addEventListener('click', () => {
+          setTimeout(() => {
+            const listElement = document.getElementById(m.id);
+            listElement?.scrollIntoView();
+          });
         });
-      });
+      }
+      applyMarkerSemantics(markerElement, !!m.popup);
 
       return marker;
     });
@@ -120,6 +138,7 @@ export function Map({
 
       const markerElement = marker.getElement();
       markerElement.classList.add('users-location-marker');
+      applyMarkerSemantics(markerElement, false);
       marker.addTo(mapboxMap.current);
 
       _markers.current.push(marker);

--- a/src/app/(app)/shared/components/map/maplibre/map.tsx
+++ b/src/app/(app)/shared/components/map/maplibre/map.tsx
@@ -55,6 +55,18 @@ export function Map({
   } | null>(null);
   const [mapError, setMapError] = useState<string | null>(null);
 
+  const applyMarkerSemantics = (markerElement: HTMLElement, interactive: boolean) => {
+    if (!interactive) {
+      markerElement.removeAttribute('aria-label');
+      markerElement.removeAttribute('role');
+      markerElement.removeAttribute('tabindex');
+      markerElement.setAttribute('aria-hidden', 'true');
+      return;
+    }
+
+    markerElement.removeAttribute('aria-hidden');
+  };
+
   useEffect(() => {
     try {
       mapLibreMap.current = new mapLibreGl.Map({
@@ -126,22 +138,23 @@ export function Map({
         const markerElement = marker.getElement();
         if (marker.getPopup()) {
           markerElement.style.cursor = 'pointer';
+          markerElement.addEventListener('click', () => {
+            setTimeout(() => {
+              const listElement = document.getElementById(m.id);
+              listElement?.scrollIntoView();
+            });
+            _markers.current?.forEach((otherMarker) => {
+              if (otherMarker !== marker) {
+                const otherPopup = otherMarker.getPopup();
+                if (otherPopup && otherPopup.isOpen()) {
+                  otherPopup.remove();
+                }
+              }
+            });
+          });
         }
         markerElement.classList.add('custom-marker');
-        markerElement.addEventListener('click', (e) => {
-          setTimeout(() => {
-            const listElement = document.getElementById(m.id);
-            listElement?.scrollIntoView();
-          });
-          _markers.current?.forEach((otherMarker) => {
-            if (otherMarker !== marker) {
-              const otherPopup = otherMarker.getPopup();
-              if (otherPopup && otherPopup.isOpen()) {
-                otherPopup.remove();
-              }
-            }
-          });
-        });
+        applyMarkerSemantics(markerElement, !!marker.getPopup());
 
         marker.addTo(mapLibreMap.current);
         bounds.extend(m.coordinates!); // Only extend if coordinates are valid
@@ -162,6 +175,7 @@ export function Map({
 
       const markerElement = marker.getElement();
       markerElement.classList.add('users-location-marker');
+      applyMarkerSemantics(markerElement, false);
       marker.addTo(mapLibreMap.current);
 
       _markers.current.push(marker);

--- a/src/app/(app)/shared/lib/html-helpers.ts
+++ b/src/app/(app)/shared/lib/html-helpers.ts
@@ -1,7 +1,44 @@
+const BLOCK_ELEMENT_REGEX =
+  /<\s*(p|div|ul|ol|li|h1|h2|h3|h4|h5|h6|blockquote|pre|table|section|article|hr)\b/i;
+const MARKDOWN_BULLET_REGEX = /^\s*[*-]\s+(.+)$/;
+
+export function normalizeStructuredContent(html: string): string {
+  if (!html || typeof html !== 'string') return '';
+
+  const lines = html.split(/\r?\n/);
+  const normalizedLines: string[] = [];
+  const listItems: string[] = [];
+
+  const flushList = () => {
+    if (listItems.length === 0) {
+      return;
+    }
+
+    normalizedLines.push(
+      `<ul>${listItems.map((item) => `<li>${item}</li>`).join('')}</ul>`,
+    );
+    listItems.length = 0;
+  };
+
+  for (const line of lines) {
+    const match = line.match(MARKDOWN_BULLET_REGEX);
+
+    if (match) {
+      listItems.push(match[1].trim());
+      continue;
+    }
+
+    flushList();
+    normalizedLines.push(line);
+  }
+
+  flushList();
+
+  return normalizedLines.join('\n');
+}
+
 export function containsBlockElements(html: string): boolean {
   if (!html || typeof html !== 'string') return false;
 
-  return /<\s*(p|div|ul|ol|li|h1|h2|h3|h4|h5|h6|blockquote|pre|table|section|article|hr)\b/i.test(
-    html,
-  );
+  return BLOCK_ELEMENT_REGEX.test(normalizeStructuredContent(html));
 }

--- a/src/app/(app)/shared/lib/parse-html.tsx
+++ b/src/app/(app)/shared/lib/parse-html.tsx
@@ -1,5 +1,6 @@
 import parse from 'html-react-parser';
 import { createLogger } from '@/lib/logger';
+import { normalizeStructuredContent } from './html-helpers';
 
 const log = createLogger('parse-html');
 
@@ -39,6 +40,7 @@ export function parseHtml(
 ) {
   if (!(html && typeof html === 'string')) return false;
 
+  html = normalizeStructuredContent(html);
   html = markdownLinksToHtml(html);
   html = linkifyHtml(html);
 


### PR DESCRIPTION
## Summary

This PR addresses a prioritized subset of WCAG violations identified in the external VPAT accessibility audit, scoped to the **search result cards**, **individual resource detail page**, **map markers**, and **shared auth dialog**. Changes are intentionally limited to semantic HTML corrections, ARIA attribute additions, and low-risk CSS adjustments. No routing, data fetching, business logic, or visual layout is changed.

**VPAT audit findings:** [2026-01 MN Disability Resources — Accessibility Review](https://docs.google.com/spreadsheets/d/1wsVTlk5KHfVlopHrjgllrDAAU4KWawsQ--HnT383kzQ/edit?usp=sharing)

**Linear ticket:** ISS-639

---

## Changes by MNADR Issue

| MNADR | Severity | Issue | File(s) Changed | Fix Applied |
|---|---|---|---|---|
| MNADR-107 | High | "See more" / "View details" link text is ambiguous outside context | `result.tsx` | Added `aria-label="{view_details}: {resource name}"` to the "View details" link so screen readers announce the destination unambiguously |
| MNADR-108 | Medium | Website URL in results card clips under text-spacing overrides | `result.tsx`, `contact-section.tsx` | Removed duplicate website URL row from result card (VPAT explicitly offers removal as fix; canonical link remains in the "Website" referral button below); added `break-all` to website URL in resource detail contact section |
| MNADR-109 | High | "Website" and "Get Directions" buttons clip text at 200% zoom | `result.tsx` | Replaced `whitespace-nowrap overflow-hidden` + `truncate` with `min-h-8 whitespace-normal py-2` on both buttons; icon gets `shrink-0` |
| MNADR-132 | Medium | Back-to-results rendered as `<button>` instead of a link | `back-to-results-button.tsx` | Replaced `<Button onClick={router.push}>` with `<Link>` styled via `buttonVariants()`; loading state kept as `<Button disabled>`; URL resolution from ISS-597 fix is unchanged |
| MNADR-133 | Medium | Phone number links have no accessible label identifying them as phone numbers | `phone-number-section.tsx` | Added `aria-describedby` referencing the label `<p>` (Voice / Text / Fax); added `aria-label` with full context (e.g. "Voice: (952) 440-3955") |
| MNADR-137 | Medium | Markdown-style bullet lists in resource descriptions rendered as raw text | `html-helpers.ts`, `parse-html.tsx` | Added `normalizeStructuredContent()` that converts `* item` / `- item` lines to `<ul><li>` before html-react-parser runs |
| MNADR-141 | Medium | Login button in auth prompt dialog incorrectly a `<button>` | `promt-auth-dialog.tsx` | Replaced `<Button onClick={signIn(...)}>` with `<a href={loginHref}>` styled via `buttonVariants()`; `callbackUrl` appended via `useEffect` to avoid SSR mismatch |
| MNADR-142 | Medium | "Other Information" facet items not marked up as a list | `facets-section.tsx` | Converted wrapping `<div>` to `<ul>` and each item `<div>` to `<li>` |
| MNADR-143 | Low | Decorative SVG icons announced as "image" by screen readers | `contact-section.tsx`, `labeled-element.tsx`, `phone-number-section.tsx`, `result.tsx`, `facets-section.tsx`, `map/mapbox/map.tsx`, `map/maplibre/map.tsx` | Added `aria-hidden="true"` to all decorative Lucide icons |
| MNADR-144 | High | Non-interactive map markers exposed as focusable buttons to screen readers | `map/mapbox/map.tsx`, `map/maplibre/map.tsx` | Added `applyMarkerSemantics(element, interactive)` helper; non-interactive markers (user-location pin, service-area) get `aria-hidden="true"` and have `role`/`tabindex`/`aria-label` removed |
| MNADR-145 | Medium | "Other Information" card heading was `<h3>` but page outline requires `<h2>` | `facets-section.tsx` | `CardTitle` replaced with `<h2 className="text-base font-semibold">` |
| MNADR-146 | Medium | Taxonomy sub-section names (`<p>`) not tagged as headings | `facets-section.tsx` | `<p>` replaced with `<h3>` per page heading outline |
| MNADR-147 | Medium | "Providing organization" label not tagged as a heading | `organization-information.tsx` | `CardDescription` replaced with `<h2 className="text-base font-medium text-muted-foreground">` |

---

## Deferred Items (not in this PR)

The following issues were investigated but deferred after reviewing git history. Each conflicts with an intentional prior engineering decision.

| MNADR | Reason for Deferral |
|---|---|
| MNADR-138 | `<button>` role on Get Directions element. Converting to a `<Link>` also requires removing the location-entry Dialog added in commit `13375e7 fix(CON-477): fix directions button`. Without that dialog, users with no detected coordinates receive only a disabled button — a functional regression. A proper fix needs to preserve the dialog flow while also giving the interactive element the correct `<a>` role. |
| MNADR-109 (directions) | Zoom text clipping on the Directions button is partially addressed by the `result.tsx` className change (`min-h-8 whitespace-normal py-2` passed via prop), but the full fix requires the MNADR-138 refactor above. |

---

## Files Changed

| File | MNADR Issues |
|---|---|
| `src/app/(app)/features/resource/components/back-to-results-button.tsx` | MNADR-132 |
| `src/app/(app)/features/resource/components/organization-information.tsx` | MNADR-147 |
| `src/app/(app)/features/resource/components/overview-components/contact-section.tsx` | MNADR-108 (partial), MNADR-143 |
| `src/app/(app)/features/resource/components/overview-components/facets-section.tsx` | MNADR-142, 143, 145, 146 |
| `src/app/(app)/features/resource/components/overview-components/labeled-element.tsx` | MNADR-143 |
| `src/app/(app)/features/resource/components/overview-components/phone-number-section.tsx` | MNADR-133, 143 |
| `src/app/(app)/features/search/components/result.tsx` | MNADR-107, 108, 109, 143 |
| `src/app/(app)/shared/components/global-dialogs/promt-auth-dialog.tsx` | MNADR-141 |
| `src/app/(app)/shared/components/map/mapbox/map.tsx` | MNADR-143, 144 |
| `src/app/(app)/shared/components/map/maplibre/map.tsx` | MNADR-143, 144 |
| `src/app/(app)/shared/lib/html-helpers.ts` | MNADR-137 |
| `src/app/(app)/shared/lib/parse-html.tsx` | MNADR-137 |

---

## Reviewer Notes

- **No routing, data fetching, or business logic is changed.** Every commit is labelled with the MNADR issue(s) it closes.
- **MNADR-108 content removal:** Removing the duplicate website URL row from the result card is a visible content change. The VPAT report explicitly lists removal as an acceptable fix ("consider removing it since there is already a website link lower down in the results card"). The canonical "Website" referral button below remains in place.
- **Map marker side-effect:** Scoping the click->scrollIntoView handler to interactive-only markers is intentional — non-interactive markers are hidden from AT and should not respond to interaction.
- **Auth dialog:** The `loginHref` state initializes to `/api/auth/signin/keycloak` (no callbackUrl) on first render to avoid SSR hydration mismatch; `useEffect` appends the encoded `callbackUrl` once `window` is available — the same URL next-auth `signIn('keycloak', {callbackUrl})` would construct.

---

## Test Guidance

- [ ] Tab to "View details" with a screen reader — confirm it announces the resource name
- [ ] Open a resource with phone numbers — confirm each `tel:` link is announced with type (Voice / Text / Fax) and number
- [ ] Open a resource with a `* item` bullet list in its description — confirm screen reader announces a list with correct item count
- [ ] Navigate to the resource detail page with a screen reader — confirm heading outline is H1 > H2 (Providing organization, Other Information) > H3 (taxonomy names)
- [ ] Zoom browser to 200% on a result card — confirm "Website" and "Get Directions" button text wraps and is not clipped
- [ ] Open the login prompt dialog — confirm "Login" is announced as a link, not a button; confirm it navigates correctly
- [ ] Focus map with keyboard — confirm user-location and service-area markers are skipped; interactive result markers are reachable
