### PR TITLE
Playwright logo rendering bug

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,3 @@ updates:
     schedule:
       interval: 'weekly'
     target-branch: 'development'
-    ignore:
-      - dependency-name: 'i18next'

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { test as base, expect, type Page } from '@playwright/test';
+import { test as base, expect, type Locator, type Page } from '@playwright/test';
 
 export const LOCALE = 'en';
 
@@ -267,6 +267,29 @@ export async function switchLanguage(page: Page, locale: 'en' | 'es') {
     { timeout: 20_000 },
   );
   await page.waitForLoadState('networkidle');
+}
+
+export async function clickAvoidingStickyHeader(locator: Locator) {
+  await locator.evaluate((element) => {
+    element.scrollIntoView({ block: 'center', inline: 'center' });
+  });
+
+  try {
+    await locator.click({ timeout: 5_000 });
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      !/intercepts pointer events|element is outside of the viewport/i.test(
+        error.message,
+      )
+    ) {
+      throw error;
+    }
+
+    await locator.evaluate((element: HTMLElement) => {
+      element.click();
+    });
+  }
 }
 
 export function parseTotalFromResultText(text: string): number {

--- a/e2e/translations.spec.ts
+++ b/e2e/translations.spec.ts
@@ -10,6 +10,7 @@ import {
   getSelectedFilterIds,
   switchLanguage,
   performSearch,
+  clickAvoidingStickyHeader,
 } from './helpers';
 
 test.describe('Language Persistence And Results Button', () => {
@@ -95,7 +96,7 @@ test.describe('Language Persistence And Results Button', () => {
 
     const resultsButton = page.getByRole('button', { name: /^Results$/i });
     await expect(resultsButton).toBeVisible({ timeout: 20_000 });
-    await resultsButton.click();
+    await clickAvoidingStickyHeader(resultsButton);
 
     await page.waitForURL(/\/search\?/);
     await expect(page.locator('#search-container')).toBeVisible({
@@ -122,7 +123,7 @@ test.describe('Language Persistence And Results Button', () => {
 
     const resultsButton = page.getByRole('button', { name: /^Resultados$/i });
     await expect(resultsButton).toBeVisible({ timeout: 20_000 });
-    await resultsButton.click();
+    await clickAvoidingStickyHeader(resultsButton);
 
     await page.waitForURL(/\/search\?/);
     await expect(page.locator('#search-container')).toBeVisible({

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "embla-carousel-autoplay": "^8.6.0",
         "embla-carousel-react": "^8.6.0",
         "html-react-parser": "^5.2.6",
-        "i18next": "25.8.13",
+        "i18next": "^25.8.18",
         "i18next-resources-to-backend": "^1.2.1",
         "ioredis": "^5.8.2",
         "jotai": "^2.12.5",
@@ -11117,9 +11117,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "25.8.13",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.13.tgz",
-      "integrity": "sha512-E0vzjBY1yM+nsFrtgkjLhST2NBkirkvOVoQa0MSldhsuZ3jUge7ZNpuwG0Cfc74zwo5ZwRzg3uOgT+McBn32iA==",
+      "version": "25.8.18",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.18.tgz",
+      "integrity": "sha512-lzY5X83BiL5AP77+9DydbrqkQHFN9hUzWGjqjLpPcp5ZOzuu1aSoKaU3xbBLSjWx9dAzW431y+d+aogxOZaKRA==",
       "funding": [
         {
           "type": "individual",
@@ -11136,7 +11136,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4"
+        "@babel/runtime": "^7.28.6"
       },
       "peerDependencies": {
         "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
     "html-react-parser": "^5.2.6",
-    "i18next": "25.8.13",
+    "i18next": "^25.8.18",
     "i18next-resources-to-backend": "^1.2.1",
     "ioredis": "^5.8.2",
     "jotai": "^2.12.5",


### PR DESCRIPTION
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/7c0fefe8-35e7-47c1-bf39-1f36894efadc" />

Despite the break to a translations test in parallel with dependabot updating i18n, that was a red herring.  The real issue is a strange rendering bug for the logo on playwright browser.  I applied a workaround but want to highlight to @u11d-bartlomiej-galezowski for review