### PR TITLE
fix(ISS-601): fix favorites management, improve e2e tests

### DIFF
--- a/e2e/favorites.spec.ts
+++ b/e2e/favorites.spec.ts
@@ -29,6 +29,9 @@ test.describe('Favorites Feature (Authenticated)', () => {
   const updatedListName = `${listName} (Updated)`;
   const updatedDescription = 'Updated by Playwright E2E test';
 
+  // Store resource name for validation
+  let firstResourceName = '';
+
   test('should create a new favorite list', async ({ page }) => {
     await goToFavorites(page);
 
@@ -50,7 +53,9 @@ test.describe('Favorites Feature (Authenticated)', () => {
     await expect(page.getByText(listName)).toBeVisible({ timeout: 10000 });
   });
 
-  test('should add a resource to the favorite list', async ({ page }) => {
+  test('should add a resource to the favorite list from search results', async ({
+    page,
+  }) => {
     await performSearch(page, {
       query: 'food',
       query_label: 'food',
@@ -61,13 +66,32 @@ test.describe('Favorites Feature (Authenticated)', () => {
       .locator('#search-container')
       .waitFor({ state: 'visible', timeout: 10_000 });
 
+    // Get the first resource name for later validation
+    const firstResourceLink = page.getByTestId('resource-link').first();
+    await expect(firstResourceLink).toBeVisible({ timeout: 30_000 });
+    firstResourceName = (await firstResourceLink.textContent()) || '';
+
     const favoriteBtn = page.getByTestId('favorite-btn').first();
     await expect(favoriteBtn).toBeVisible({ timeout: 30_000 });
     await favoriteBtn.click();
 
+    // Wait for the dialog to load (skeleton disappears)
+    await expect(
+      page.getByTestId('favorites-loading-skeleton'),
+    ).not.toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('favorites-list-loaded')).toBeAttached({
+      timeout: 10_000,
+    });
+
     const searchBar = page.getByTestId('favorites-search-input');
     await expect(searchBar).toBeVisible({ timeout: 10_000 });
     await searchBar.fill(listName);
+
+    // Wait for debounce and filtering to complete
+    await page.waitForTimeout(5000);
+    await expect(
+      page.getByTestId('favorites-loading-skeleton'),
+    ).not.toBeVisible({ timeout: 10_000 });
 
     const listRow = page.getByText(listName).first();
     await expect(listRow).toBeVisible({ timeout: 10_000 });
@@ -80,8 +104,13 @@ test.describe('Favorites Feature (Authenticated)', () => {
       timeout: 10_000,
     });
 
+    // Verify the resource is now marked as in the list (HeartOff icon)
+    const removeBtn = page.getByTestId('remove-from-list-btn').first();
+    await expect(removeBtn).toBeVisible({ timeout: 10_000 });
+
     await page.getByRole('button', { name: 'Close' }).click();
 
+    // Navigate to the favorites list and verify the resource is there
     await goToFavorites(page);
 
     const listCard = page.getByText(listName).first();
@@ -90,7 +119,9 @@ test.describe('Favorites Feature (Authenticated)', () => {
     await waitForFavoriteListPage(page);
     await expect(page.getByText(listName).first()).toBeVisible();
     await expect(page.getByText(listDescription).first()).toBeVisible();
-    await waitForFavoriteListPage(page);
+    await expect(page.getByText(firstResourceName).first()).toBeVisible({
+      timeout: 10_000,
+    });
   });
 
   test('should update the favorite list name and description', async ({
@@ -130,24 +161,247 @@ test.describe('Favorites Feature (Authenticated)', () => {
     });
   });
 
-  test('should remove a resource from the favorite list', async ({ page }) => {
+  test('should remove a resource from the favorite list using the remove button', async ({
+    page,
+  }) => {
     await goToFavorites(page);
 
     const updatedCard = page.getByText(updatedListName).first();
     await updatedCard.click();
     await waitForFavoriteListPage(page);
 
-    const removeTrigger = page.getByTestId('remove-favorite-btn').first();
+    // Verify the resource is present before removal
+    await expect(page.getByText(firstResourceName).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const removeTrigger = page.getByTestId('remove-from-list-btn').first();
     await expect(removeTrigger).toBeVisible({ timeout: 10_000 });
     await removeTrigger.click();
 
-    const removeButton = page.getByTestId('remove-favorite-confirm-btn');
+    const removeButton = page.getByTestId(
+      'remove-from-current-list-confirm-btn',
+    );
     await expect(removeButton).toBeVisible({ timeout: 10_000 });
     await removeButton.click();
 
+    await expect(page.getByText('Removed from list')).toBeVisible({
+      timeout: 10_000,
+    });
+
     await page.waitForLoadState('networkidle');
-    const resourceLinks = page.getByTestId('resource-link');
-    await expect(resourceLinks).toHaveCount(0, { timeout: 10_000 });
+
+    // Verify the specific resource is no longer visible (more resilient than checking count)
+    await expect(page.getByText(firstResourceName)).toHaveCount(0, {
+      timeout: 10_000,
+    });
+  });
+
+  test('should add a resource from search results and remove it via dialog', async ({
+    page,
+  }) => {
+    await performSearch(page, {
+      query: 'housing',
+      query_label: 'housing',
+      query_type: 'text',
+    });
+
+    await page
+      .locator('#search-container')
+      .waitFor({ state: 'visible', timeout: 10_000 });
+
+    // Get resource name
+    const resourceLink = page.getByTestId('resource-link').first();
+    await expect(resourceLink).toBeVisible({ timeout: 30_000 });
+    const resourceName = (await resourceLink.textContent()) || '';
+
+    // Add to list
+    const favoriteBtn = page.getByTestId('favorite-btn').first();
+    await favoriteBtn.click();
+
+    // Wait for the dialog to load
+    await expect(
+      page.getByTestId('favorites-loading-skeleton'),
+    ).not.toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('favorites-list-loaded')).toBeAttached({
+      timeout: 10_000,
+    });
+
+    const searchBar = page.getByTestId('favorites-search-input');
+    await expect(searchBar).toBeVisible({ timeout: 10_000 });
+    await searchBar.fill(updatedListName);
+
+    // Wait for debounce and filtering to complete
+    await page.waitForTimeout(5000);
+    await expect(
+      page.getByTestId('favorites-loading-skeleton'),
+    ).not.toBeVisible({ timeout: 10_000 });
+
+    const addBtn = page.getByTestId('add-to-list-btn').first();
+    await expect(addBtn).toBeVisible({ timeout: 10_000 });
+    await addBtn.click();
+
+    await expect(page.getByText('Added to list')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Now remove it from dialog (HeartOff button)
+    const removeFromListBtn = page.getByTestId('remove-from-list-btn').first();
+    await expect(removeFromListBtn).toBeVisible({ timeout: 10_000 });
+    await removeFromListBtn.click();
+
+    await expect(page.getByText('Removed from list')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Close dialog
+    await page.getByRole('button', { name: 'Close' }).click();
+
+    // Verify it's not in the list
+    await goToFavorites(page);
+    const listCard = page.getByText(updatedListName).first();
+    await listCard.click();
+    await waitForFavoriteListPage(page);
+
+    await expect(page.getByText(resourceName)).toHaveCount(0, {
+      timeout: 10_000,
+    });
+  });
+
+  test('should add a resource from resource details page', async ({ page }) => {
+    await performSearch(page, {
+      query: 'shelter',
+      query_label: 'shelter',
+      query_type: 'text',
+    });
+
+    await page
+      .locator('#search-container')
+      .waitFor({ state: 'visible', timeout: 10_000 });
+
+    // Click on first resource to go to details page
+    const firstResourceLink = page.getByTestId('resource-link').first();
+    await expect(firstResourceLink).toBeVisible({ timeout: 30_000 });
+    const resourceName = (await firstResourceLink.textContent()) || '';
+    await firstResourceLink.click();
+
+    // Wait for resource page to load
+    await page.waitForURL(/\/search\/[a-f0-9-]{36}/, { timeout: 10_000 });
+    await page.waitForLoadState('networkidle');
+
+    // Add to favorites from resource page
+    const favoriteBtn = page.getByTestId('favorite-btn').first();
+    await expect(favoriteBtn).toBeVisible({ timeout: 10_000 });
+    await favoriteBtn.click();
+
+    // Wait for the dialog to load
+    await expect(
+      page.getByTestId('favorites-loading-skeleton'),
+    ).not.toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('favorites-list-loaded')).toBeAttached({
+      timeout: 10_000,
+    });
+
+    const searchBar = page.getByTestId('favorites-search-input');
+    await expect(searchBar).toBeVisible({ timeout: 10_000 });
+    await searchBar.fill(updatedListName);
+
+    // Wait for debounce and filtering to complete
+    await page.waitForTimeout(5000);
+    await expect(
+      page.getByTestId('favorites-loading-skeleton'),
+    ).not.toBeVisible({ timeout: 10_000 });
+
+    const addBtn = page.getByTestId('add-to-list-btn').first();
+    await expect(addBtn).toBeVisible({ timeout: 10_000 });
+    await addBtn.click();
+
+    await expect(page.getByText('Added to list')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByRole('button', { name: 'Close' }).click();
+
+    // Verify it's in the list
+    await goToFavorites(page);
+    const listCard = page.getByText(updatedListName).first();
+    await listCard.click();
+    await waitForFavoriteListPage(page);
+
+    await expect(page.getByText(resourceName).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Clean up - remove it
+    const removeTrigger = page.getByTestId('remove-from-list-btn').first();
+    await removeTrigger.click();
+    const removeButton = page.getByTestId(
+      'remove-from-current-list-confirm-btn',
+    );
+    await removeButton.click();
+    await expect(page.getByText('Removed from list')).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test('should show correct state in favorites dialog (in list vs not in list)', async ({
+    page,
+  }) => {
+    await performSearch(page, {
+      query: 'food',
+      query_label: 'food',
+      query_type: 'text',
+    });
+
+    await page
+      .locator('#search-container')
+      .waitFor({ state: 'visible', timeout: 10_000 });
+
+    const favoriteBtn = page.getByTestId('favorite-btn').first();
+    await favoriteBtn.click();
+
+    // Wait for the dialog to load
+    await expect(
+      page.getByTestId('favorites-loading-skeleton'),
+    ).not.toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('favorites-list-loaded')).toBeAttached({
+      timeout: 10_000,
+    });
+
+    const searchBar = page.getByTestId('favorites-search-input');
+    await expect(searchBar).toBeVisible({ timeout: 10_000 });
+    await searchBar.fill(updatedListName);
+
+    // Wait for debounce and filtering to complete
+    await page.waitForTimeout(5000);
+    await expect(
+      page.getByTestId('favorites-loading-skeleton'),
+    ).not.toBeVisible({ timeout: 10_000 });
+
+    // Should show "Add to list" button initially (resource not in list)
+    const addBtn = page.getByTestId('add-to-list-btn').first();
+    await expect(addBtn).toBeVisible({ timeout: 10_000 });
+
+    // Add it
+    await addBtn.click();
+    await expect(page.getByText('Added to list')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Should now show "Remove from list" button (resource is in list)
+    const removeBtn = page.getByTestId('remove-from-list-btn').first();
+    await expect(removeBtn).toBeVisible({ timeout: 10_000 });
+
+    // Remove it
+    await removeBtn.click();
+    await expect(page.getByText('Removed from list')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Should show "Add to list" button again
+    await expect(addBtn).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole('button', { name: 'Close' }).click();
   });
 
   test('should delete the favorite list', async ({ page }) => {

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -75,10 +75,12 @@ export async function performSearch(page: Page, params: SearchParams) {
 export async function goToFavorites(page: Page) {
   await page.getByTestId('my-stuff-btn').click();
   await page.getByTestId('favorites-btn').click();
+  await page.waitForURL(/\/favorites(\?|$)/, { timeout: 15000 });
   await page.waitForLoadState('networkidle');
 }
 
 export async function waitForFavoriteListPage(page: Page) {
+  await page.waitForURL(/\/favorites\/[a-f0-9-]{24}/, { timeout: 15000 });
   await page
     .getByTestId('back-to-favorites')
     .waitFor({ state: 'visible', timeout: 15000 });

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -13,6 +13,8 @@
     "added_to_list_message": "This resource has been added to your list.",
     "already_exists": "Already exists",
     "already_exists_message": "This resource already exists in your list.",
+    "remove_from_list_title": "Remove from list?",
+    "remove_from_list_description": "This resource will be removed from this list. You can add it back later if needed.",
     "removed_from_list": "Removed from list",
     "removed_from_list_message": "This resource has been removed from your list.",
     "updated_list": "Updated list",

--- a/src/app/(app)/features/favorites/components/favorites-section.tsx
+++ b/src/app/(app)/features/favorites/components/favorites-section.tsx
@@ -37,7 +37,7 @@ export function FavoritesSection({ cardLayout }: FavoritesSectionProps) {
   const componentToPrint = useRef<HTMLDivElement>(null);
   const { stringifiedSearchParams } = useClientSearchParams();
 
-  const handleRemoveFromList = (listId: string, favoriteId: string) => {
+  const handleRemoveFromList = (_listId: string, favoriteId: string) => {
     // Optimistically update the local atom by filtering out the removed favorite
     setFavoriteList((prev) => ({
       ...prev,

--- a/src/app/(app)/features/search/components/search-card-components/resource-name.tsx
+++ b/src/app/(app)/features/search/components/search-card-components/resource-name.tsx
@@ -3,6 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import { SearchCardComponentProps } from './types';
 import { AddToFavoritesButton } from '@/app/(app)/shared/components/add-to-favorites-button';
+import { RemoveFromFavoriteListButton } from '@/app/(app)/shared/components/remove-from-favorite-list-button';
 import { Typography } from '@/app/(app)/shared/components/ui/typography';
 
 export function ResourceNameComponent({ result }: SearchCardComponentProps) {
@@ -10,6 +11,11 @@ export function ResourceNameComponent({ result }: SearchCardComponentProps) {
   const name = result.name || t('name_unavailable', { ns: 'page-search' });
 
   const url = `/search/${result.id}${process.env.NEXT_PUBLIC_WITH_TRAILING_SLASHES === 'true' ? '/' : ''}`;
+
+  // Render RemoveFromFavoriteListButton when viewing a specific favorite list
+  const isInFavoriteListContext = Boolean(
+    result.currentListId && result.onRemoveFromList,
+  );
 
   return (
     <div className="flex flex-row justify-between gap-2">
@@ -23,12 +29,20 @@ export function ResourceNameComponent({ result }: SearchCardComponentProps) {
         {name}
       </Typography>
       <div className="flex flex-shrink-0 items-center print:hidden">
-        <AddToFavoritesButton
-          size="icon"
-          serviceAtLocationId={result.id}
-          currentListId={result.currentListId}
-          onRemoveFromList={result.onRemoveFromList}
-        />
+        {isInFavoriteListContext ? (
+          <RemoveFromFavoriteListButton
+            serviceAtLocationId={result.id}
+            resourceName={name}
+            currentListId={result.currentListId!}
+            onRemoveFromList={result.onRemoveFromList!}
+          />
+        ) : (
+          <AddToFavoritesButton
+            size="icon"
+            serviceAtLocationId={result.id}
+            resourceName={name}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/app/(app)/shared/components/add-to-favorites-button.tsx
+++ b/src/app/(app)/shared/components/add-to-favorites-button.tsx
@@ -36,20 +36,12 @@ type AddToFavoritesButtonProps = {
   size?: 'default' | 'icon';
   serviceAtLocationId: string;
   resourceName?: string;
-  siblings?: number;
-  boundaries?: number;
-  currentListId?: string;
-  onRemoveFromList?: (listId: string, favoriteId: string) => void;
 };
 
 export function AddToFavoritesButton({
   size = 'default',
   serviceAtLocationId,
   resourceName,
-  siblings = 1,
-  boundaries = 1,
-  currentListId,
-  onRemoveFromList,
 }: AddToFavoritesButtonProps) {
   const appConfig = useAppConfig();
   const session = useSession();
@@ -63,13 +55,13 @@ export function AddToFavoritesButton({
   const [searchValue, setSearchValue] = useState('');
   const [favoritesState, setFavoritesState] = useState<{
     data: FavoriteListState[];
-    status: 'loading' | 'refreshing' | 'success';
+    status: 'idle' | 'refreshing' | 'loading' | 'success';
     page: number;
     limit: number;
     totalCount: number;
   }>({
     data: [],
-    status: 'loading',
+    status: 'idle',
     page: 1,
     limit: 5,
     totalCount: 0,
@@ -103,20 +95,20 @@ export function AddToFavoritesButton({
       }));
     }
   }, [
-    session,
-    searchValue,
-    appConfig,
+    session.status,
+    appConfig.tenantId,
     favoritesState.page,
     favoritesState.limit,
-    serviceAtLocationId,
+    searchValue,
     i18n.language,
+    serviceAtLocationId,
   ]);
 
   useEffect(() => {
     if (open) {
       refreshFavoritesList();
     }
-  }, [refreshFavoritesList, open]);
+  }, [open, refreshFavoritesList]);
 
   const toggleFavoriteInList = (listId: string, isInList: boolean) => {
     return async () => {
@@ -135,11 +127,6 @@ export function AddToFavoritesButton({
           toast.success(t('favorites.removed_from_list'), {
             description: t('favorites.removed_from_list_message'),
           });
-
-          // If we're viewing this list, notify parent to update UI
-          if (currentListId === listId && onRemoveFromList) {
-            onRemoveFromList(listId, serviceAtLocationId);
-          }
 
           await refreshFavoritesList();
         } else {
@@ -237,6 +224,7 @@ export function AddToFavoritesButton({
                 placeholder={t('modal.add_to_list.search_list')}
                 initialValue={searchValue}
                 onChange={setSearchValue}
+                debounceDelay={500}
               />
               <Button
                 variant="outline"
@@ -247,15 +235,6 @@ export function AddToFavoritesButton({
                 {t('modal.create_list.create_a_list')}
               </Button>
             </div>
-
-            {(favoritesState.status === 'success' ||
-              favoritesState.status === 'refreshing') &&
-              favoritesState.data.length === 0 &&
-              searchValue?.length > 0 && (
-                <p className="text-sm text-muted-foreground">
-                  {t('modal.add_to_list.not_found')}
-                </p>
-              )}
 
             <Separator />
 
@@ -270,10 +249,11 @@ export function AddToFavoritesButton({
 
               {favoritesState.status === 'loading' && (
                 <>
+                  <Skeleton
+                    className="col-span-2 h-6"
+                    data-testid="favorites-loading-skeleton"
+                  />
                   <Skeleton className="col-span-2 h-6" />
-
-                  <Skeleton className="col-span-2 h-6" />
-
                   <Skeleton className="h-6" />
                 </>
               )}
@@ -281,6 +261,17 @@ export function AddToFavoritesButton({
               {(favoritesState.status === 'success' ||
                 favoritesState.status === 'refreshing') && (
                 <>
+                  <div data-testid="favorites-list-loaded" className="sr-only">
+                    Favorites loaded
+                  </div>
+
+                  {favoritesState.data.length === 0 &&
+                    searchValue?.length > 0 && (
+                      <p className="col-span-5 text-sm text-muted-foreground">
+                        {t('modal.add_to_list.not_found')}
+                      </p>
+                    )}
+
                   {favoritesState.data.map((el) => {
                     const isInList = el.containsResource ?? false;
                     return (
@@ -342,8 +333,8 @@ export function AddToFavoritesButton({
                     )}
                     totalResults={favoritesState.totalCount}
                     activePage={favoritesState.page}
-                    siblings={siblings}
-                    boundaries={boundaries}
+                    siblings={1}
+                    boundaries={1}
                     onPageChange={(page) =>
                       setFavoritesState((prev) => ({ ...prev, page }))
                     }

--- a/src/app/(app)/shared/components/remove-from-favorite-list-button.tsx
+++ b/src/app/(app)/shared/components/remove-from-favorite-list-button.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { HeartOff, Loader2 } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from './ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
+import { cn } from '../lib/utils';
+import { useAppConfig } from '../hooks/use-app-config';
+import { removeFavoriteFromList } from '../serverActions/favorites/removeFavoriteFromList';
+
+type RemoveFromFavoriteListButtonProps = {
+  serviceAtLocationId: string;
+  resourceName?: string;
+  currentListId: string;
+  onRemoveFromList: (listId: string, favoriteId: string) => void;
+};
+
+export function RemoveFromFavoriteListButton({
+  serviceAtLocationId,
+  resourceName,
+  currentListId,
+  onRemoveFromList,
+}: RemoveFromFavoriteListButtonProps) {
+  const appConfig = useAppConfig();
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const { t } = useTranslation('common');
+
+  const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  const handleRemoveFromCurrentList = async () => {
+    try {
+      setIsRemoving(true);
+
+      await removeFavoriteFromList(
+        {
+          resourceId: serviceAtLocationId,
+          favoriteListId: currentListId,
+        },
+        appConfig.tenantId,
+      );
+
+      toast.success(t('favorites.removed_from_list'), {
+        description: t('favorites.removed_from_list_message'),
+      });
+
+      // Notify parent to update UI
+      onRemoveFromList(currentListId, serviceAtLocationId);
+
+      setRemoveConfirmOpen(false);
+    } catch (error) {
+      toast.error(t('message.error'), {
+        description: t('favorites.unable_to_update_list_message'),
+      });
+    } finally {
+      setIsRemoving(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        ref={triggerRef}
+        className={cn('flex size-6 gap-1')}
+        size={'icon'}
+        variant={'ghost'}
+        aria-label={
+          resourceName
+            ? `${t('call_to_action.remove_from_list')} ${resourceName}`
+            : t('call_to_action.remove_from_list')
+        }
+        aria-haspopup="dialog"
+        data-testid="remove-from-list-btn"
+        onClick={() => setRemoveConfirmOpen(true)}
+      >
+        <HeartOff className="size-6" aria-hidden="true" />
+      </Button>
+
+      <Dialog open={removeConfirmOpen} onOpenChange={setRemoveConfirmOpen}>
+        <DialogContent
+          restoreFocusElement={triggerRef.current}
+          closeLabel={t('call_to_action.close')}
+        >
+          <DialogHeader>
+            <DialogTitle>{t('favorites.remove_from_list_title')}</DialogTitle>
+            <DialogDescription>
+              {t('favorites.remove_from_list_description')}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setRemoveConfirmOpen(false)}
+              disabled={isRemoving}
+            >
+              {t('call_to_action.cancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleRemoveFromCurrentList}
+              disabled={isRemoving}
+              data-testid="remove-from-current-list-confirm-btn"
+              loading={isRemoving}
+            >
+              {t('call_to_action.remove')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
Previously, favorites modal was shown whenever user clicked the heart button.

<img width="926" height="802" alt="image" src="https://github.com/user-attachments/assets/6f7c7e04-c28c-4cb6-aaf2-8ef0c606c2bd" />

It turned out it does not make sense to show modal with other favorite lists if user is already in favorite list context

<img width="934" height="654" alt="image" src="https://github.com/user-attachments/assets/7aabaaa7-a413-4cc2-b13f-d30c15f46907" />

So this PR introduces `RemoveFromFavoriteListButton` and uses it in favorite list page