### PR TITLE
Tour responsiveness and scroll locking

### DIFF
--- a/src/app/(app)/features/home/components/hero-section.tsx
+++ b/src/app/(app)/features/home/components/hero-section.tsx
@@ -10,6 +10,8 @@ import { useFlag } from '@/app/(app)/shared/hooks/use-flag';
 import { useTranslation } from 'react-i18next';
 import { Image } from '@/app/(app)/shared/components/image';
 
+type TourPositionPreference = 'above' | 'below';
+
 export function HeroSection() {
   const appConfig = useAppConfig();
   const { isOpen, setCurrentStep, setIsOpen, setSteps } = useTour();
@@ -17,33 +19,100 @@ export function HeroSection() {
   const showHomePageTour = useFlag('showHomePageTour');
   const homeSearchTriggerRef = useRef<HTMLButtonElement | null>(null);
 
-  const getStepOnePosition = useCallback<
-    Extract<NonNullable<StepType['position']>, (...args: never[]) => unknown>
-  >(
-    ({ windowHeight, windowWidth, top, bottom, left, right, width, height }) => {
+  const getResponsiveTourPosition = useCallback(
+    (
+      {
+        windowHeight,
+        windowWidth,
+        top,
+        bottom,
+        left,
+        right,
+        width,
+        height,
+      }: {
+        windowHeight: number;
+        windowWidth: number;
+        top: number;
+        bottom: number;
+        left: number;
+        right: number;
+        width: number;
+        height: number;
+      },
+      preferredDirection: TourPositionPreference,
+    ): 'center' | [number, number] => {
+      const minInset = 16;
+      const gap = 24;
+
       if (windowWidth < 768) {
         return 'center';
       }
 
-      const popoverWidth = width || Math.min(576, windowWidth - 32);
-      const popoverHeight = height || 0;
+      const popoverWidth = width || Math.min(576, windowWidth - minInset * 2);
+      const popoverHeight =
+        height || Math.min(windowHeight - minInset * 2, 24 * 18);
       const targetWidth = right - left;
       const targetCenterX = left + targetWidth / 2;
-      const minInset = 16;
       const x = Math.min(
         Math.max(targetCenterX - popoverWidth / 2, minInset),
         windowWidth - popoverWidth - minInset,
       );
-      const spaceBelow = windowHeight - bottom;
-      const spaceAbove = top;
+      const spaceBelow = windowHeight - bottom - gap - minInset;
+      const spaceAbove = top - gap - minInset;
+
+      if (
+        windowHeight < 720 ||
+        (spaceBelow < popoverHeight && spaceAbove < popoverHeight)
+      ) {
+        return 'center';
+      }
+
+      const preferredY =
+        preferredDirection === 'below'
+          ? bottom + gap
+          : Math.max(top - popoverHeight - gap, minInset);
+      const fallbackY =
+        preferredDirection === 'below'
+          ? Math.max(top - popoverHeight - gap, minInset)
+          : bottom + gap;
+      const canUsePreferred =
+        preferredDirection === 'below'
+          ? spaceBelow >= popoverHeight
+          : spaceAbove >= popoverHeight;
       const y =
-        spaceBelow >= 360 || spaceBelow >= spaceAbove
-          ? bottom + 24
-          : Math.max(top - popoverHeight - 24, minInset);
+        canUsePreferred ||
+        (preferredDirection === 'below'
+          ? spaceBelow >= spaceAbove
+          : spaceAbove >= spaceBelow)
+          ? preferredY
+          : fallbackY;
 
       return [x, y];
     },
     [],
+  );
+
+  const getStepOnePosition = useCallback<
+    Extract<NonNullable<StepType['position']>, (...args: never[]) => unknown>
+  >(
+    (positionProps) => getResponsiveTourPosition(positionProps, 'below'),
+    [getResponsiveTourPosition],
+  );
+
+  const getStepTwoPosition = useCallback<
+    Extract<NonNullable<StepType['position']>, (...args: never[]) => unknown>
+  >(
+    (positionProps) =>
+      getResponsiveTourPosition(
+        {
+          ...positionProps,
+          top: positionProps.top + positionProps.height * 0.15,
+          bottom: positionProps.bottom - positionProps.height * 0.65,
+        },
+        'above',
+      ),
+    [getResponsiveTourPosition],
   );
 
   const buildTourSteps = useCallback((): StepType[] => {
@@ -53,6 +122,7 @@ export function HeroSection() {
       {
         selector: searchTarget ?? '.search-box',
         position: getStepOnePosition,
+        resizeObservables: ['.search-box', '.categories'],
         content: (
           <div className="flex flex-col gap-2">
             <p>{t('tour.step_1.paragraph_1')}</p>
@@ -63,7 +133,8 @@ export function HeroSection() {
       },
       {
         selector: '.categories',
-        position: 'center',
+        position: getStepTwoPosition,
+        resizeObservables: ['.categories'],
         content: (
           <div className="flex flex-col gap-2">
             <p>{t('tour.step_2.paragraph_1')}</p>
@@ -72,7 +143,7 @@ export function HeroSection() {
         ),
       },
     ];
-  }, [getStepOnePosition, t]);
+  }, [getStepOnePosition, getStepTwoPosition, t]);
 
   const enableTour = () => {
     createTourEvent(null);

--- a/src/app/(app)/shared/context/tour-provider.tsx
+++ b/src/app/(app)/shared/context/tour-provider.tsx
@@ -7,10 +7,12 @@ import {
   type ProviderProps,
 } from '@reactour/tour';
 import { useTranslation } from 'react-i18next';
+import { getScrollbarWidth } from '@/app/(app)/shared/lib/utils';
 
 const TOUR_DIALOG_ID = 'home-page-tour-dialog';
 const TOUR_TITLE_ID = 'home-page-tour-title';
 const TOUR_TRIGGER_SELECTOR = '[data-home-tour-trigger="true"]';
+const TOUR_CONTENT_SCROLLABLE_CLASS = 'home-tour-scrollable-content';
 
 const focusableSelector = [
   'button:not([disabled])',
@@ -22,6 +24,8 @@ const focusableSelector = [
 ].join(',');
 
 const DISABLED_TOUR_TABINDEX_ATTR = 'data-tour-original-tabindex';
+
+let lockedBodyScrollY = 0;
 
 function getTourPopover(): HTMLElement | null {
   return document.querySelector<HTMLElement>(
@@ -109,6 +113,49 @@ function getPaginationButtons(controlsDiv: HTMLElement): HTMLButtonElement[] {
   return Array.from(
     controlsDiv.querySelectorAll<HTMLButtonElement>(':scope > div > button'),
   );
+}
+
+function getContentContainer(
+  popover: HTMLElement,
+  controlsDiv: HTMLElement | null,
+): HTMLElement | null {
+  return Array.from(popover.children).find((child) => {
+    if (!(child instanceof HTMLElement)) return false;
+    if (child === controlsDiv) return false;
+    if (child.classList.contains('reactour__close-button')) return false;
+    if (child.tagName === 'SPAN') return false;
+    return true;
+  }) as HTMLElement | null;
+}
+
+function patchPopoverLayout(
+  popover: HTMLElement,
+  controlsDiv: HTMLElement | null,
+): void {
+  popover.style.display = 'flex';
+  popover.style.flexDirection = 'column';
+  popover.style.gap = '1rem';
+  popover.style.overflow = 'visible';
+  popover.style.padding = '1rem 1rem 1.25rem';
+  popover.style.boxSizing = 'border-box';
+
+  const contentContainer = getContentContainer(popover, controlsDiv);
+  if (contentContainer) {
+    contentContainer.classList.add(TOUR_CONTENT_SCROLLABLE_CLASS);
+    contentContainer.style.flex = '1 1 auto';
+    contentContainer.style.minHeight = '0';
+    contentContainer.style.overflowY = 'auto';
+    contentContainer.style.overscrollBehavior = 'contain';
+    contentContainer.style.paddingRight = '0.25rem';
+  }
+
+  if (controlsDiv) {
+    controlsDiv.style.flexShrink = '0';
+    controlsDiv.style.marginTop = '0';
+    controlsDiv.style.paddingTop = '0.75rem';
+    controlsDiv.style.borderTop = '1px solid rgba(15, 23, 42, 0.12)';
+    controlsDiv.style.background = 'inherit';
+  }
 }
 
 function patchDialogRole(popover: HTMLElement, tourLabel: string): void {
@@ -224,10 +271,41 @@ function patchTourPopover(
   patchCloseButton(popover);
 
   const controlsDiv = getControlsDiv(popover);
+  patchPopoverLayout(popover, controlsDiv);
+
   if (controlsDiv) {
     patchPaginationDots(controlsDiv, currentStep);
     patchNavButtons(controlsDiv, currentStep, stepCount);
   }
+}
+
+function lockBodyScroll(): void {
+  lockedBodyScrollY = window.scrollY;
+  const scrollbarWidth = getScrollbarWidth();
+
+  document.body.style.position = 'fixed';
+  document.body.style.top = `-${lockedBodyScrollY}px`;
+  document.body.style.width = '100%';
+  document.body.style.left = '0';
+  document.body.style.right = '0';
+
+  if (scrollbarWidth > 0) {
+    document.body.style.paddingRight = `${scrollbarWidth}px`;
+  }
+}
+
+function unlockBodyScroll(): void {
+  const parsedTop = Number.parseInt(document.body.style.top || '0', 10);
+  const scrollY = Number.isNaN(parsedTop) ? lockedBodyScrollY : -parsedTop;
+
+  document.body.style.position = '';
+  document.body.style.top = '';
+  document.body.style.width = '';
+  document.body.style.left = '';
+  document.body.style.right = '';
+  document.body.style.paddingRight = '';
+
+  window.scrollTo(0, scrollY);
 }
 
 function TourAccessibilityEnhancer() {
@@ -265,6 +343,7 @@ function TourAccessibilityEnhancer() {
     };
 
     safePatch();
+    const viewport = window.visualViewport;
 
     const popover = getTourPopover();
     const observer = new MutationObserver(safePatch);
@@ -343,6 +422,8 @@ function TourAccessibilityEnhancer() {
 
     document.addEventListener('keydown', handleKeyDown, true);
     document.addEventListener('focusin', handleFocusIn, true);
+    window.addEventListener('resize', safePatch);
+    viewport?.addEventListener('resize', safePatch);
     wasOpenRef.current = true;
 
     return () => {
@@ -350,6 +431,8 @@ function TourAccessibilityEnhancer() {
       window.cancelAnimationFrame(focusFrame);
       document.removeEventListener('keydown', handleKeyDown, true);
       document.removeEventListener('focusin', handleFocusIn, true);
+      window.removeEventListener('resize', safePatch);
+      viewport?.removeEventListener('resize', safePatch);
       restoreBackgroundFocus();
     };
   }, [currentStep, isOpen, steps, t]);
@@ -367,13 +450,22 @@ export const TourProvider = ({ children }: PropsWithChildren) => {
       steps={[]}
       className="home-tour-popover"
       scrollSmooth
+      afterOpen={lockBodyScroll}
+      beforeClose={unlockBodyScroll}
+      inViewThreshold={{ x: 16, y: 24 }}
       disableInteraction={({ currentStep }) => currentStep === 0}
       styles={{
+        badge: (baseStyles) => ({
+          ...baseStyles,
+          top: '-0.625rem',
+          left: '-0.625rem',
+        }),
         popover: (baseStyles) => ({
           ...baseStyles,
           width: 'min(36rem, calc(100vw - 2rem))',
           maxWidth: 'calc(100vw - 2rem)',
           maxHeight: 'calc(100dvh - 2rem)',
+          padding: '1rem 1rem 1.25rem',
         }),
       }}
     >


### PR DESCRIPTION
Resolving Kylie's findings: https://linear.app/connect211/issue/ISS-637/mnadr-035-to-mnadr-039-and-mnadr-061-to-mnadr-073#comment-317e16e8

Experiencing issues when the vertical height of the screen cannot contain the full box for the react tour. This makes it so that the user wants to scroll the screen, to see the full tour options and have access to click the right arrow and see the next tour step, however scrolling disconnects the highlight and the tour box from their intended location resulting in strange behavior.

Further, while addressing this issue, I found that the positioning of the second step wasn't responsive which causes problems for users with high zoom / a11y needs.