### PR TITLE
feat: cache tenant branding and legal config snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -351,7 +351,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1045.0.tgz",
       "integrity": "sha512-fsuO3Y6t+3Ro9Bsg41DKj4Sfy53CGSrhnMldNplWmG8Tx0UbYk+YDa4RD1hVlJpERw4JBmPkl0+J9qlxMh1pcA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1201,7 +1200,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1401,7 +1399,6 @@
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -1475,7 +1472,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2660,7 +2656,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "body-scroll-lock": "4.0.0-beta.0",
         "focus-trap": "7.5.4",
@@ -2682,7 +2677,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -4159,7 +4153,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4249,7 +4242,6 @@
       "resolved": "https://registry.npmjs.org/@payloadcms/next/-/next-3.84.1.tgz",
       "integrity": "sha512-T7f7Ja4l4Z6QM/oSM8MWJY63xyNQmWxUswDgssXl1/D0hQIVQASXMeZvXiXLQwg/g4f9s5anKTUNIx32dtHxWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/modifiers": "9.0.0",
@@ -4381,7 +4373,6 @@
       "resolved": "https://registry.npmjs.org/@payloadcms/ui/-/ui-3.84.1.tgz",
       "integrity": "sha512-L9trD3/LcK1fiGg4AFexy9AQm4upMzRbicZFTNU/ac+x5o6Pwyr7FzrvbtfCr0l2t6QhawLBZmBCZJA8oBF2uA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@date-fns/tz": "1.2.0",
         "@dnd-kit/core": "6.3.1",
@@ -4449,7 +4440,6 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -6506,7 +6496,6 @@
       "integrity": "sha512-3DgfkukFyC/sE/VuYjaUUWoFfuVjPK55vOFDsxD56XXynFMCZDYFogH2l/hDfOsQAm1myoU/1xByJ3tWqtulXA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@babel/generator": "^7.28.0",
         "@babel/parser": "^7.28.0",
@@ -6760,7 +6749,6 @@
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -6779,7 +6767,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6790,7 +6777,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6824,7 +6810,8 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/ua-parser-js": {
       "version": "0.7.39",
@@ -6895,7 +6882,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -7152,7 +7138,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7479,7 +7464,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8443,6 +8427,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -8713,8 +8698,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-autoplay": {
       "version": "8.6.0",
@@ -8844,7 +8828,6 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8925,7 +8908,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9895,6 +9877,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
       "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -10207,7 +10190,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -10527,6 +10509,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -10560,7 +10543,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -10822,6 +10804,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -11108,6 +11091,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -11911,7 +11895,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
       "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
@@ -12484,7 +12467,6 @@
       "resolved": "https://registry.npmjs.org/payload/-/payload-3.84.1.tgz",
       "integrity": "sha512-+aPqqeYsffrzaYmsX/Qt+mHNgcTUyc5TIjjPOaMIrG6nDx6siZ2h9Gv3b3RKAVPt7PWkHI+ooEW3cQbwiDd99Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "^15.1.5",
         "@payloadcms/translations": "3.84.1",
@@ -12665,7 +12647,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -12919,7 +12900,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13070,7 +13050,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -13103,7 +13082,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13427,7 +13405,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13540,7 +13517,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -13774,8 +13750,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -14017,8 +13992,7 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/scmp": {
       "version": "2.1.0",
@@ -14861,7 +14835,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15531,7 +15504,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16223,7 +16195,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/(payload)/api/getTenantBasicConfig/route.ts
+++ b/src/app/(payload)/api/getTenantBasicConfig/route.ts
@@ -30,7 +30,6 @@ export const GET = async (request: Request) => {
     `tenant_basic_config:${host}`,
     async () => {
       const tenant = await findTenantByHost(host);
-
       return {
         enabledLocales: tenant ? tenant.enabledLocales : [],
         defaultLocale: tenant ? tenant.defaultLocale : 'en',

--- a/src/payload/collections/ResourceDirectories/hooks/createPushLocaleConfigToCache.ts
+++ b/src/payload/collections/ResourceDirectories/hooks/createPushLocaleConfigToCache.ts
@@ -1,4 +1,8 @@
-import type { CollectionAfterChangeHook, Payload, PayloadRequest } from 'payload';
+import type {
+  CollectionAfterChangeHook,
+  Payload,
+  PayloadRequest,
+} from 'payload';
 
 import { apiConfigCacheService } from '@/cacheService';
 import { createLogger } from '@/lib/logger';
@@ -36,10 +40,14 @@ export function createPushLocaleConfigToCache<T>(
     req: PayloadRequest,
     locale: string | undefined = req.locale,
   ): Promise<ResourceDirectory> => {
-    const tenantId = typeof doc.tenant === 'string' ? doc.tenant : doc.tenant?.id;
+    const tenantId =
+      typeof doc.tenant === 'string' ? doc.tenant : doc.tenant?.id;
 
     if (typeof tenantId !== 'string') {
-      log.warn({ tenantId }, `Invalid tenant ID; skipping ${configLabel} cache update`);
+      log.warn(
+        { tenantId },
+        `Invalid tenant ID; skipping ${configLabel} cache update`,
+      );
       return doc;
     }
 
@@ -55,10 +63,19 @@ export function createPushLocaleConfigToCache<T>(
       }
 
       const { payload } = req;
-      const byLocale = await buildFn(payload, tenantId, tenant.enabledLocales, doc, locale);
+      const byLocale = await buildFn(
+        payload,
+        tenantId,
+        tenant.enabledLocales,
+        doc,
+        locale,
+      );
 
       if (!byLocale) {
-        log.info({ tenantId }, `No ${configLabel} built for tenant; skipping cache update`);
+        log.info(
+          { tenantId },
+          `No ${configLabel} built for tenant; skipping cache update`,
+        );
         return doc;
       }
 
@@ -67,16 +84,24 @@ export function createPushLocaleConfigToCache<T>(
         await apiConfigCacheService.set(cacheKey, JSON.stringify(config));
       }
 
-      log.info({ tenantId, localeCount: byLocale.size }, `${configLabel} cache updated`);
+      log.info(
+        { tenantId, localeCount: byLocale.size },
+        `${configLabel} cache updated`,
+      );
     } catch (error) {
-      log.error({ err: error, tenantId }, `Error pushing ${configLabel} to cache`);
+      log.error(
+        { err: error, tenantId },
+        `Error pushing ${configLabel} to cache`,
+      );
     }
 
     return doc;
   };
 
-  const afterChangeHook: CollectionAfterChangeHook<ResourceDirectory> = ({ doc, req }) =>
-    pushToCache(doc, req);
+  const afterChangeHook: CollectionAfterChangeHook<ResourceDirectory> = ({
+    doc,
+    req,
+  }) => pushToCache(doc, req);
 
   return { pushToCache, afterChangeHook };
 }

--- a/src/payload/collections/ResourceDirectories/hooks/createPushLocaleConfigToCache.ts
+++ b/src/payload/collections/ResourceDirectories/hooks/createPushLocaleConfigToCache.ts
@@ -1,0 +1,82 @@
+import type { CollectionAfterChangeHook, Payload, PayloadRequest } from 'payload';
+
+import { apiConfigCacheService } from '@/cacheService';
+import { createLogger } from '@/lib/logger';
+import type { ResourceDirectory } from '@/payload/payload-types';
+
+import { findTenantById } from '../../Tenants/actions';
+
+type BuildFn<T> = (
+  payload: Payload,
+  tenantId: string,
+  enabledLocales: string[],
+  doc: ResourceDirectory,
+  locale: string | undefined,
+) => Promise<Map<string, T> | null>;
+
+type GetKeyFn = (tenantId: string, locale: string) => string;
+
+export function createPushLocaleConfigToCache<T>(
+  buildFn: BuildFn<T>,
+  getKeyFn: GetKeyFn,
+  loggerName: string,
+  configLabel: string,
+): {
+  pushToCache: (
+    doc: ResourceDirectory,
+    req: PayloadRequest,
+    locale?: string,
+  ) => Promise<ResourceDirectory>;
+  afterChangeHook: CollectionAfterChangeHook<ResourceDirectory>;
+} {
+  const log = createLogger(loggerName);
+
+  const pushToCache = async (
+    doc: ResourceDirectory,
+    req: PayloadRequest,
+    locale: string | undefined = req.locale,
+  ): Promise<ResourceDirectory> => {
+    const tenantId = typeof doc.tenant === 'string' ? doc.tenant : doc.tenant?.id;
+
+    if (typeof tenantId !== 'string') {
+      log.warn({ tenantId }, `Invalid tenant ID; skipping ${configLabel} cache update`);
+      return doc;
+    }
+
+    try {
+      const tenant = await findTenantById(tenantId, false);
+
+      if (!tenant?.enabledLocales) {
+        log.warn(
+          { tenantId },
+          `No tenant or enabled locales found; skipping ${configLabel} cache update`,
+        );
+        return doc;
+      }
+
+      const { payload } = req;
+      const byLocale = await buildFn(payload, tenantId, tenant.enabledLocales, doc, locale);
+
+      if (!byLocale) {
+        log.info({ tenantId }, `No ${configLabel} built for tenant; skipping cache update`);
+        return doc;
+      }
+
+      for (const [localeKey, config] of byLocale.entries()) {
+        const cacheKey = getKeyFn(tenantId, localeKey);
+        await apiConfigCacheService.set(cacheKey, JSON.stringify(config));
+      }
+
+      log.info({ tenantId, localeCount: byLocale.size }, `${configLabel} cache updated`);
+    } catch (error) {
+      log.error({ err: error, tenantId }, `Error pushing ${configLabel} to cache`);
+    }
+
+    return doc;
+  };
+
+  const afterChangeHook: CollectionAfterChangeHook<ResourceDirectory> = ({ doc, req }) =>
+    pushToCache(doc, req);
+
+  return { pushToCache, afterChangeHook };
+}

--- a/src/payload/collections/ResourceDirectories/hooks/pushBrandingConfigToCache.ts
+++ b/src/payload/collections/ResourceDirectories/hooks/pushBrandingConfigToCache.ts
@@ -1,0 +1,13 @@
+import { buildBrandingConfigCache } from '../utilities/buildBrandingConfigCache';
+import { getBrandingConfigKey } from '../utilities/getBrandingConfigKey';
+import { createPushLocaleConfigToCache } from './createPushLocaleConfigToCache';
+
+const { pushToCache: pushBrandingConfigToCache, afterChangeHook: pushBrandingConfigToCacheAfterChangeHook } =
+  createPushLocaleConfigToCache(
+    buildBrandingConfigCache,
+    getBrandingConfigKey,
+    'pushBrandingConfigToCache',
+    'branding config',
+  );
+
+export { pushBrandingConfigToCache, pushBrandingConfigToCacheAfterChangeHook };

--- a/src/payload/collections/ResourceDirectories/hooks/pushBrandingConfigToCache.ts
+++ b/src/payload/collections/ResourceDirectories/hooks/pushBrandingConfigToCache.ts
@@ -2,12 +2,14 @@ import { buildBrandingConfigCache } from '../utilities/buildBrandingConfigCache'
 import { getBrandingConfigKey } from '../utilities/getBrandingConfigKey';
 import { createPushLocaleConfigToCache } from './createPushLocaleConfigToCache';
 
-const { pushToCache: pushBrandingConfigToCache, afterChangeHook: pushBrandingConfigToCacheAfterChangeHook } =
-  createPushLocaleConfigToCache(
-    buildBrandingConfigCache,
-    getBrandingConfigKey,
-    'pushBrandingConfigToCache',
-    'branding config',
-  );
+const {
+  pushToCache: pushBrandingConfigToCache,
+  afterChangeHook: pushBrandingConfigToCacheAfterChangeHook,
+} = createPushLocaleConfigToCache(
+  buildBrandingConfigCache,
+  getBrandingConfigKey,
+  'pushBrandingConfigToCache',
+  'branding config',
+);
 
 export { pushBrandingConfigToCache, pushBrandingConfigToCacheAfterChangeHook };

--- a/src/payload/collections/ResourceDirectories/hooks/pushLegalConfigToCache.ts
+++ b/src/payload/collections/ResourceDirectories/hooks/pushLegalConfigToCache.ts
@@ -2,12 +2,14 @@ import { buildLegalConfigCache } from '../utilities/buildLegalConfigCache';
 import { getLegalConfigKey } from '../utilities/getLegalConfigKey';
 import { createPushLocaleConfigToCache } from './createPushLocaleConfigToCache';
 
-const { pushToCache: pushLegalConfigToCache, afterChangeHook: pushLegalConfigToCacheAfterChangeHook } =
-  createPushLocaleConfigToCache(
-    buildLegalConfigCache,
-    getLegalConfigKey,
-    'pushLegalConfigToCache',
-    'legal config',
-  );
+const {
+  pushToCache: pushLegalConfigToCache,
+  afterChangeHook: pushLegalConfigToCacheAfterChangeHook,
+} = createPushLocaleConfigToCache(
+  buildLegalConfigCache,
+  getLegalConfigKey,
+  'pushLegalConfigToCache',
+  'legal config',
+);
 
 export { pushLegalConfigToCache, pushLegalConfigToCacheAfterChangeHook };

--- a/src/payload/collections/ResourceDirectories/hooks/pushLegalConfigToCache.ts
+++ b/src/payload/collections/ResourceDirectories/hooks/pushLegalConfigToCache.ts
@@ -1,0 +1,13 @@
+import { buildLegalConfigCache } from '../utilities/buildLegalConfigCache';
+import { getLegalConfigKey } from '../utilities/getLegalConfigKey';
+import { createPushLocaleConfigToCache } from './createPushLocaleConfigToCache';
+
+const { pushToCache: pushLegalConfigToCache, afterChangeHook: pushLegalConfigToCacheAfterChangeHook } =
+  createPushLocaleConfigToCache(
+    buildLegalConfigCache,
+    getLegalConfigKey,
+    'pushLegalConfigToCache',
+    'legal config',
+  );
+
+export { pushLegalConfigToCache, pushLegalConfigToCacheAfterChangeHook };

--- a/src/payload/collections/ResourceDirectories/index.ts
+++ b/src/payload/collections/ResourceDirectories/index.ts
@@ -8,7 +8,9 @@ import { autoTranslate } from './hooks/autoTranslate';
 import { disableService } from './hooks/disableResourceDirectoryService';
 import { invalidateApiCache } from './hooks/invalidateApiCache';
 import { preventUpdateInDisabledLocale } from './hooks/preventUpdateInDisabledLocale';
+import { pushBrandingConfigToCacheAfterChangeHook } from './hooks/pushBrandingConfigToCache';
 import { pushFacetsToCacheAfterChangeHook } from './hooks/pushFacetsToCache';
+import { pushLegalConfigToCacheAfterChangeHook } from './hooks/pushLegalConfigToCache';
 import { revalidateCache } from './hooks/revalidateCache';
 import { setTenantIdAsId } from './hooks/setTenantIdAsId';
 import { syncKeycloakRealmBrandingAfterChange } from './hooks/syncKeycloakBrandingAfterChange';
@@ -63,6 +65,8 @@ export const ResourceDirectories: CollectionConfig = {
       revalidateCache,
       autoTranslate,
       pushFacetsToCacheAfterChangeHook,
+      pushBrandingConfigToCacheAfterChangeHook,
+      pushLegalConfigToCacheAfterChangeHook,
       syncKeycloakRealmBrandingAfterChange,
       invalidateApiCache,
     ],

--- a/src/payload/collections/ResourceDirectories/utilities/buildBrandingConfigCache.ts
+++ b/src/payload/collections/ResourceDirectories/utilities/buildBrandingConfigCache.ts
@@ -1,0 +1,111 @@
+import type { Payload } from 'payload';
+
+import { createLogger } from '@/lib/logger';
+import { assertValidLocale } from '@/payload/i18n/locales';
+import type { ResourceDirectory, TenantMedia } from '@/payload/payload-types';
+import type { BrandingConfig } from '@/types/brandingConfig';
+
+const DEFAULT_PRIMARY_COLOR = '#005191';
+const DEFAULT_SECONDARY_COLOR = '#FFB351';
+const DEFAULT_BORDER_RADIUS = '6px';
+const DEFAULT_HEADER_GRADIENT_START = '#ffffff';
+const DEFAULT_HEADER_GRADIENT_END = '#ffffff';
+
+const log = createLogger('buildBrandingConfigCache');
+
+function getMediaUrl(media?: TenantMedia | number | null): string | undefined {
+  if (typeof media === 'number' || !media) return undefined;
+  return media?.url || undefined;
+}
+
+function buildBrandingForLocale(
+  resourceDirectory: ResourceDirectory,
+  tenantId: string,
+  locale: string,
+): BrandingConfig {
+  const brand = resourceDirectory.brand;
+  const newLayout = resourceDirectory.newLayout;
+
+  return {
+    tenantId,
+    locale,
+    revision: resourceDirectory.updatedAt ?? new Date().toISOString(),
+    resolvedFrom: {
+      source: 'payload',
+      resourceDirectoryId: resourceDirectory.id,
+    },
+    brand: {
+      name: resourceDirectory.name,
+      logoUrl: getMediaUrl(brand.logo),
+      heroUrl: getMediaUrl(brand.hero),
+      newLayoutLogoUrl: getMediaUrl(newLayout?.logo),
+      newLayoutHeroUrl: getMediaUrl(newLayout?.hero),
+      faviconUrl: getMediaUrl(brand.favicon),
+      openGraphUrl: getMediaUrl(brand.openGraph),
+      copyright: brand.copyright ?? undefined,
+    },
+    theme: {
+      newLayoutEnabled: newLayout?.enabled ?? false,
+      primaryColor: brand.theme.primaryColor ?? DEFAULT_PRIMARY_COLOR,
+      secondaryColor: brand.theme.secondaryColor ?? DEFAULT_SECONDARY_COLOR,
+      borderRadius: brand.theme.borderRadius ?? DEFAULT_BORDER_RADIUS,
+      headerGradient: {
+        start: newLayout?.headerStart ?? DEFAULT_HEADER_GRADIENT_START,
+        end: newLayout?.headerEnd ?? DEFAULT_HEADER_GRADIENT_END,
+      },
+    },
+    metadata: {
+      title: brand.meta?.title ?? undefined,
+      description: brand.meta?.description ?? undefined,
+    },
+    contact: {
+      phoneNumber: brand.phoneNumber ?? undefined,
+      feedbackUrl: brand.feedbackUrl ?? undefined,
+    },
+  };
+}
+
+/**
+ * Builds a BrandingConfig snapshot for each enabled locale of a tenant.
+ * Returns a map of locale -> BrandingConfig, or null if the resource
+ * directory cannot be resolved for any locale.
+ */
+export async function buildBrandingConfigCache(
+  payload: Payload,
+  tenantId: string,
+  enabledLocales: string[],
+  _currentDoc: ResourceDirectory,
+  _currentLocale: string | undefined,
+): Promise<Map<string, BrandingConfig> | null> {
+  const results = new Map<string, BrandingConfig>();
+
+  for (const locale of enabledLocales) {
+    assertValidLocale(locale);
+
+    const resourceDirectory = await payload
+      .find({
+        collection: 'resource-directories',
+        where: { tenant: { equals: tenantId } },
+        locale,
+        limit: 1,
+        depth: 1,
+      })
+      .then((result) => result.docs[0] || null);
+
+    if (!resourceDirectory) {
+      log.warn(
+        { tenantId, locale },
+        'No resource directory found for locale; skipping branding config snapshot',
+      );
+      continue;
+    }
+
+    results.set(locale, buildBrandingForLocale(resourceDirectory, tenantId, locale));
+  }
+
+  if (results.size === 0) {
+    return null;
+  }
+
+  return results;
+}

--- a/src/payload/collections/ResourceDirectories/utilities/buildBrandingConfigCache.ts
+++ b/src/payload/collections/ResourceDirectories/utilities/buildBrandingConfigCache.ts
@@ -100,7 +100,10 @@ export async function buildBrandingConfigCache(
       continue;
     }
 
-    results.set(locale, buildBrandingForLocale(resourceDirectory, tenantId, locale));
+    results.set(
+      locale,
+      buildBrandingForLocale(resourceDirectory, tenantId, locale),
+    );
   }
 
   if (results.size === 0) {

--- a/src/payload/collections/ResourceDirectories/utilities/buildLegalConfigCache.ts
+++ b/src/payload/collections/ResourceDirectories/utilities/buildLegalConfigCache.ts
@@ -1,0 +1,55 @@
+import type { Payload } from 'payload';
+
+import type { ResourceDirectory } from '@/payload/payload-types';
+import type { LegalConfig } from '@/types/legalConfig';
+
+import { buildLocaleConfigMap } from './buildLocaleConfigMap';
+
+function buildLegalForLocale(
+  resourceDirectory: ResourceDirectory,
+  tenantId: string,
+  locale: string,
+): LegalConfig {
+  return {
+    tenantId,
+    locale,
+    revision: resourceDirectory.updatedAt ?? new Date().toISOString(),
+    resolvedFrom: {
+      source: 'payload',
+      resourceDirectoryId: resourceDirectory.id,
+    },
+    privacyPolicy: {
+      enabled: resourceDirectory.privacyPolicyPage?.enabled ?? false,
+      title: resourceDirectory.privacyPolicyPage?.title ?? undefined,
+      content: resourceDirectory.privacyPolicyPage?.content ?? undefined,
+    },
+    termsOfUse: {
+      enabled: resourceDirectory.termsOfUsePage?.enabled ?? false,
+      title: resourceDirectory.termsOfUsePage?.title ?? undefined,
+      content: resourceDirectory.termsOfUsePage?.content ?? undefined,
+    },
+  };
+}
+
+/**
+ * Builds a LegalConfig snapshot for each enabled locale of a tenant.
+ * Returns a map of locale -> LegalConfig, or null if the resource
+ * directory cannot be resolved for any locale.
+ */
+export async function buildLegalConfigCache(
+  payload: Payload,
+  tenantId: string,
+  enabledLocales: string[],
+  currentDoc: ResourceDirectory,
+  currentLocale: string | undefined,
+): Promise<Map<string, LegalConfig> | null> {
+  return buildLocaleConfigMap(
+    payload,
+    tenantId,
+    enabledLocales,
+    currentDoc,
+    currentLocale,
+    buildLegalForLocale,
+    'legal config',
+  );
+}

--- a/src/payload/collections/ResourceDirectories/utilities/buildLocaleConfigMap.ts
+++ b/src/payload/collections/ResourceDirectories/utilities/buildLocaleConfigMap.ts
@@ -18,7 +18,11 @@ export async function buildLocaleConfigMap<T>(
   enabledLocales: string[],
   currentDoc: ResourceDirectory,
   currentLocale: string | undefined,
-  buildForLocale: (resourceDirectory: ResourceDirectory, tenantId: string, locale: string) => T,
+  buildForLocale: (
+    resourceDirectory: ResourceDirectory,
+    tenantId: string,
+    locale: string,
+  ) => T,
   logLabel: string,
 ): Promise<Map<string, T> | null> {
   const results = new Map<string, T>();

--- a/src/payload/collections/ResourceDirectories/utilities/buildLocaleConfigMap.ts
+++ b/src/payload/collections/ResourceDirectories/utilities/buildLocaleConfigMap.ts
@@ -1,0 +1,57 @@
+import type { Payload } from 'payload';
+
+import { createLogger } from '@/lib/logger';
+import { assertValidLocale } from '@/payload/i18n/locales';
+import type { ResourceDirectory } from '@/payload/payload-types';
+
+const log = createLogger('buildLocaleConfigMap');
+
+/**
+ * Fetches the ResourceDirectory for each enabled locale and passes it to
+ * `buildForLocale`, returning a locale→T map. Returns null if no locale
+ * produced a result. Re-uses `currentDoc` for the locale being saved to
+ * avoid an extra round-trip to the database.
+ */
+export async function buildLocaleConfigMap<T>(
+  payload: Payload,
+  tenantId: string,
+  enabledLocales: string[],
+  currentDoc: ResourceDirectory,
+  currentLocale: string | undefined,
+  buildForLocale: (resourceDirectory: ResourceDirectory, tenantId: string, locale: string) => T,
+  logLabel: string,
+): Promise<Map<string, T> | null> {
+  const results = new Map<string, T>();
+
+  for (const locale of enabledLocales) {
+    assertValidLocale(locale);
+
+    const resourceDirectory =
+      locale === currentLocale && currentDoc
+        ? currentDoc
+        : await payload
+            .find({
+              collection: 'resource-directories',
+              where: { tenant: { equals: tenantId } },
+              locale,
+              limit: 1,
+            })
+            .then((result) => result.docs[0] || null);
+
+    if (!resourceDirectory) {
+      log.warn(
+        { tenantId, locale },
+        `No resource directory found for locale; skipping ${logLabel} snapshot`,
+      );
+      continue;
+    }
+
+    results.set(locale, buildForLocale(resourceDirectory, tenantId, locale));
+  }
+
+  if (results.size === 0) {
+    return null;
+  }
+
+  return results;
+}

--- a/src/payload/collections/ResourceDirectories/utilities/getBrandingConfigKey.ts
+++ b/src/payload/collections/ResourceDirectories/utilities/getBrandingConfigKey.ts
@@ -1,0 +1,3 @@
+export const getBrandingConfigKey = (tenantId: string, locale: string) => {
+  return `branding_config:${tenantId}:${locale}`;
+};

--- a/src/payload/collections/ResourceDirectories/utilities/getLegalConfigKey.ts
+++ b/src/payload/collections/ResourceDirectories/utilities/getLegalConfigKey.ts
@@ -1,0 +1,3 @@
+export const getLegalConfigKey = (tenantId: string, locale: string) => {
+  return `legal_config:${tenantId}:${locale}`;
+};

--- a/src/payload/endpoints/populateApiConfigCache.ts
+++ b/src/payload/endpoints/populateApiConfigCache.ts
@@ -91,7 +91,11 @@ export const populateApiConfigCache: Endpoint = {
         if (resourceDirectory) {
           await pushFacetsToCache(resourceDirectory, req, defaultLocale);
           facetsTriggered++;
-          await pushBrandingConfigToCache(resourceDirectory, req, defaultLocale);
+          await pushBrandingConfigToCache(
+            resourceDirectory,
+            req,
+            defaultLocale,
+          );
           brandingTriggered++;
           await pushLegalConfigToCache(resourceDirectory, req, defaultLocale);
           legalTriggered++;

--- a/src/payload/endpoints/populateApiConfigCache.ts
+++ b/src/payload/endpoints/populateApiConfigCache.ts
@@ -5,7 +5,9 @@ import { defaultLocale } from '@/payload/i18n/locales';
 import { Tenant } from '@/payload/payload-types';
 
 import { pushOrchestrationConfigToCache } from '../collections/OrchestrationConfig/hooks/pushOrchestrationConfigToCache';
+import { pushBrandingConfigToCache } from '../collections/ResourceDirectories/hooks/pushBrandingConfigToCache';
 import { pushFacetsToCache } from '../collections/ResourceDirectories/hooks/pushFacetsToCache';
+import { pushLegalConfigToCache } from '../collections/ResourceDirectories/hooks/pushLegalConfigToCache';
 import { pushEnabledLocalesToCache } from '../collections/Tenants/hooks/pushEnabledLocalesToCache';
 import { pushRealmIdToCache } from '../collections/Tenants/hooks/pushRealmIdToCache';
 import { isSuperAdmin } from '../collections/Users/access/roles';
@@ -32,9 +34,9 @@ export const populateApiConfigCache: Endpoint = {
       );
     }
 
-    const { payload } = req;
-
     try {
+      const { payload } = req;
+
       const tenants: Tenant[] = [];
       let page = 1;
       let hasNextPage = true;
@@ -55,6 +57,8 @@ export const populateApiConfigCache: Endpoint = {
       let realmIdTriggered = 0;
       let enabledLocalesTriggered = 0;
       let facetsTriggered = 0;
+      let brandingTriggered = 0;
+      let legalTriggered = 0;
       let orchestrationConfigTriggered = 0;
 
       for (const tenant of tenants) {
@@ -87,6 +91,10 @@ export const populateApiConfigCache: Endpoint = {
         if (resourceDirectory) {
           await pushFacetsToCache(resourceDirectory, req, defaultLocale);
           facetsTriggered++;
+          await pushBrandingConfigToCache(resourceDirectory, req, defaultLocale);
+          brandingTriggered++;
+          await pushLegalConfigToCache(resourceDirectory, req, defaultLocale);
+          legalTriggered++;
         }
 
         const [orchestrationConfig] = await payload
@@ -119,6 +127,8 @@ export const populateApiConfigCache: Endpoint = {
           realmIdTriggered,
           enabledLocalesTriggered,
           facetsTriggered,
+          brandingTriggered,
+          legalTriggered,
           orchestrationConfigTriggered,
         },
         'API config cache population completed',
@@ -131,6 +141,8 @@ export const populateApiConfigCache: Endpoint = {
           realmIdTriggered,
           enabledLocalesTriggered,
           facetsTriggered,
+          brandingTriggered,
+          legalTriggered,
           orchestrationConfigTriggered,
         },
         { status: 200 },

--- a/src/types/brandingConfig.ts
+++ b/src/types/brandingConfig.ts
@@ -1,0 +1,46 @@
+export type BrandingConfigTheme = {
+  /** Whether the newLayout chrome (gradient header, alternate logo) is active for this tenant. */
+  newLayoutEnabled: boolean;
+  primaryColor: string;
+  secondaryColor: string;
+  borderRadius: string;
+  headerGradient: {
+    start: string;
+    end: string;
+  };
+};
+
+export type BrandingConfigResolvedFrom = {
+  source: 'payload';
+  resourceDirectoryId: string;
+};
+
+export type BrandingConfig = {
+  tenantId: string;
+  locale: string;
+  revision: string;
+  resolvedFrom: BrandingConfigResolvedFrom;
+  brand: {
+    name: string;
+    /** Primary brand logo (brand tab). */
+    logoUrl?: string;
+    /** Brand tab hero image. */
+    heroUrl?: string;
+    /** Alternate logo shown when newLayout is enabled (newLayout tab). */
+    newLayoutLogoUrl?: string;
+    /** New layout hero image. */
+    newLayoutHeroUrl?: string;
+    faviconUrl?: string;
+    openGraphUrl?: string;
+    copyright?: string;
+  };
+  theme: BrandingConfigTheme;
+  metadata: {
+    title?: string;
+    description?: string;
+  };
+  contact: {
+    phoneNumber?: string;
+    feedbackUrl?: string;
+  };
+};

--- a/src/types/legalConfig.ts
+++ b/src/types/legalConfig.ts
@@ -1,0 +1,19 @@
+export type LegalPage = {
+  enabled: boolean;
+  title?: string;
+  content?: string;
+};
+
+export type LegalConfigResolvedFrom = {
+  source: 'payload';
+  resourceDirectoryId: string;
+};
+
+export type LegalConfig = {
+  tenantId: string;
+  locale: string;
+  revision: string;
+  resolvedFrom: LegalConfigResolvedFrom;
+  privacyPolicy: LegalPage;
+  termsOfUse: LegalPage;
+};


### PR DESCRIPTION
## Summary
- add Payload-side builders and hooks to publish per-locale branding and legal config snapshots into the API cache
- include tenant branding metadata needed downstream, including asset URLs and legal page content
- update the cache population endpoint so existing tenants can be backfilled without manual resaves

## Why
This is the Payload half of the CMS config work. It makes tenant branding and legal settings available in the shared cache so downstream services can read them without querying Payload directly.

Once this and the companion `Norse-API` PR are merged, you will be able to consume stable tenant-level branding and legal configuration from internal API endpoints instead of relying on direct CMS reads.  This is necessary for the feedback form which I plan to put into the growing ServiceNet toolbox.  Users of ServiceNet may not in the future have a search frontend presence, so being able to source this flexibly from Payload and decouple the feedback form from Norse is critical for a future where we expand beyond 211s paying for just search engine services.