### PR TITLE
fix: remove strategy attribute from UmamiScript component

### DIFF
--- a/src/app/(app)/shared/components/umami-script.tsx
+++ b/src/app/(app)/shared/components/umami-script.tsx
@@ -17,7 +17,6 @@ export function UmamiScript({
       src={scriptUrl}
       data-website-id={websiteId}
       nonce={nonce}
-      strategy="beforeInteractive"
     />
   );
 }


### PR DESCRIPTION
## Why it helped

**`beforeInteractive` renders a real `<script>` tag in the server HTML:**

```html
<!-- Server-rendered HTML sent to browser -->
<script
  id="umami-script"
  src="http://localhost:..."
  data-website-id="318160c2..."
  nonce="YTc2NjZlMD..."
></script>
```

This tag exists in the HTML string that React parses to build its initial fiber tree. React records `nonce="YTc2NjZlMD..."` in that fiber. Then the browser strips the nonce attribute from the DOM. When React hydrates and reads the live DOM, it sees `nonce=""`. Mismatch.

---

**`afterInteractive` renders nothing in the server HTML:**

```html
<!-- Server-rendered HTML sent to browser -->
<!-- no <script> tag here at all -->
```

There is no element in the server HTML for React to put in its fiber tree. React has nothing to reconcile against the DOM. The script is instead injected imperatively by Next.js's Script runtime after hydration — the element is created fresh in JavaScript, React never owns it, and no comparison is ever made.

---

**In one sentence:** `beforeInteractive` makes the `<script>` tag part of React's reconciliation tree, so the browser's nonce-stripping becomes React's problem. `afterInteractive` keeps the `<script>` tag outside React's tree entirely, so the browser's nonce-stripping is invisible to React.